### PR TITLE
feat: migrate GP backend from sklearn to pure NumPy

### DIFF
--- a/dynoai/core/gp_engine.py
+++ b/dynoai/core/gp_engine.py
@@ -1,0 +1,307 @@
+"""
+DynoAI — Pure NumPy Gaussian Process Engine
+=============================================
+
+Matérn ν=5/2 kernel with ARD length scales.  No sklearn, no scipy.
+Deterministic for fixed inputs under pinned BLAS threads.
+
+Design constraints (from holdout harness contract):
+    - n_train ≤ 150, n_pred up to 256+ (arbitrary grid)
+    - First fit < 10ms for 150×150 Cholesky
+    - Cached predict < 2ms for 256×150 prediction
+    - Bit-identical across repeated calls (no randomness)
+    - Frozen hyperparameters (no optimizer)
+
+Semantics:
+    - Target y is absolute VE % (not residual over physics prior)
+    - X normalization handled by caller (gp_surrogate.py)
+    - y is internally centered + scaled (replicating sklearn normalize_y=True)
+    - Returned std is for latent function f (not observation y)
+
+Author: Thunderhorse Tuning / DynoAI
+Version: 1.0.0 (NumPy backend, parity target with sklearn)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Frozen hyperparameter defaults
+# ---------------------------------------------------------------------------
+# These are seed values matching the sklearn kernel's initial config.
+# They must be validated via holdout harness before production use.
+DEFAULT_LENGTH_SCALES = np.array([0.3, 0.3], dtype=np.float64)
+DEFAULT_SIGNAL_VAR = 1.0     # No ConstantKernel in current sklearn config
+DEFAULT_NOISE_VAR = 0.15     # WhiteKernel(0.1) + alpha(0.05) combined
+DEFAULT_JITTER = 1e-8        # Numerical stability only
+
+
+# ---------------------------------------------------------------------------
+# Kernel math
+# ---------------------------------------------------------------------------
+def _scaled_sqdist(A: NDArray, B: NDArray) -> NDArray:
+    """
+    Squared Euclidean distance matrix between rows of A and B.
+
+    Args:
+        A: (n, d) array, already scaled by length_scales
+        B: (m, d) array, already scaled by length_scales
+
+    Returns:
+        (n, m) matrix of squared distances, clamped ≥ 0
+    """
+    # Stable computation: ||a-b||² = ||a||² + ||b||² - 2 a·b
+    A_sq = np.sum(A * A, axis=1)[:, None]  # (n, 1)
+    B_sq = np.sum(B * B, axis=1)[None, :]  # (1, m)
+    D2 = A_sq + B_sq - 2.0 * (A @ B.T)
+    np.maximum(D2, 0.0, out=D2)
+    return D2
+
+
+def _matern52(r: NDArray, signal_var: float = 1.0) -> NDArray:
+    """
+    Matérn ν=5/2 kernel evaluated at distance r.
+
+    k(r) = signal_var * (1 + √5·r + 5/3·r²) · exp(-√5·r)
+
+    Args:
+        r: (n, m) non-negative distance matrix
+        signal_var: kernel amplitude (k(0) = signal_var)
+
+    Returns:
+        (n, m) kernel matrix
+    """
+    s5 = np.sqrt(5.0)
+    return signal_var * (1.0 + s5 * r + (5.0 / 3.0) * r * r) * np.exp(-s5 * r)
+
+
+# ---------------------------------------------------------------------------
+# Cache structure
+# ---------------------------------------------------------------------------
+@dataclass
+class _FitCache:
+    """Cached Cholesky factorization and solve results from fit()."""
+
+    X_train_scaled: NDArray          # (n, d) — pre-divided by length_scales
+    y_mean: float                    # center of y normalization
+    y_std: float                     # scale of y normalization
+    L: NDArray                       # (n, n) — lower Cholesky of K + noise*I
+    alpha: NDArray                   # (n,) or (n, 1) — K^{-1} y_norm
+    signal_var: float
+    noise_var: float
+    jitter: float
+    length_scales: NDArray
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+class MaternGP:
+    """
+    Gaussian Process regressor with Matérn 5/2 kernel.
+
+    Pure NumPy.  Frozen hyperparameters.  Deterministic.
+
+    Usage::
+
+        gp = MaternGP(length_scales=[0.3, 0.3], signal_var=1.0, noise_var=0.15)
+        gp.fit(X_train, y_train)
+        mean, std = gp.predict(X_pred)
+
+    The returned ``std`` is the **latent function** posterior standard deviation.
+    For observation-level uncertainty: ``std_y = sqrt(std**2 + noise_var)``.
+    """
+
+    def __init__(
+        self,
+        length_scales: Optional[NDArray] = None,
+        signal_var: float = DEFAULT_SIGNAL_VAR,
+        noise_var: float = DEFAULT_NOISE_VAR,
+        jitter: float = DEFAULT_JITTER,
+        normalize_y: bool = True,
+    ):
+        """
+        Args:
+            length_scales: ARD length scales, shape (d,). Default [0.3, 0.3].
+            signal_var: Kernel amplitude. k(x,x) = signal_var at zero distance.
+            noise_var: Observation noise variance added to training diagonal.
+            jitter: Tiny numerical stabilizer added to diagonal (independent of noise).
+            normalize_y: If True, center+scale y by mean/std before fitting,
+                         and un-transform on prediction (replicates sklearn behavior).
+        """
+        self.length_scales = np.asarray(
+            length_scales if length_scales is not None else DEFAULT_LENGTH_SCALES,
+            dtype=np.float64,
+        )
+        self.signal_var = float(signal_var)
+        self.noise_var = float(noise_var)
+        self.jitter = float(jitter)
+        self.normalize_y = normalize_y
+
+        self._cache: Optional[_FitCache] = None
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._cache is not None
+
+    # ------------------------------------------------------------------
+    # fit
+    # ------------------------------------------------------------------
+    def fit(self, X_train: NDArray, y_train: NDArray) -> None:
+        """
+        Fit the GP on training data.  Caches Cholesky factorization.
+
+        Args:
+            X_train: (n, d) training inputs, already X-normalized by caller.
+            y_train: (n,) training targets (absolute VE %).
+
+        Raises:
+            np.linalg.LinAlgError: If Cholesky fails (shouldn't with jitter).
+        """
+        X = np.asarray(X_train, dtype=np.float64)
+        y = np.asarray(y_train, dtype=np.float64).ravel()
+        n = X.shape[0]
+
+        if n == 0:
+            self._cache = None
+            return
+
+        # -- y normalization (center + scale) --
+        if self.normalize_y:
+            y_mean = float(np.mean(y))
+            y_std = float(np.std(y)) if n > 1 else 1.0
+            if y_std < 1e-12:
+                y_std = 1.0  # Avoid division by zero for constant y
+            y_norm = (y - y_mean) / y_std
+        else:
+            y_mean = 0.0
+            y_std = 1.0
+            y_norm = y.copy()
+
+        # -- Pre-scale X by length scales (done once) --
+        ls = self.length_scales
+        X_scaled = X / ls  # (n, d)
+
+        # -- Kernel matrix K(X, X) --
+        D2 = _scaled_sqdist(X_scaled, X_scaled)
+        r = np.sqrt(D2)
+        K = _matern52(r, self.signal_var)
+
+        # -- Add noise + jitter to diagonal --
+        diag_add = self.noise_var + self.jitter
+        K[np.diag_indices(n)] += diag_add
+
+        # -- Cholesky factorization --
+        L = np.linalg.cholesky(K)  # (n, n) lower triangular
+
+        # -- Solve for alpha: K^{-1} y_norm via two triangular solves --
+        # L v = y_norm  →  v = L^{-1} y_norm
+        # L^T alpha = v  →  alpha = K^{-1} y_norm
+        v = np.linalg.solve(L, y_norm)
+        alpha = np.linalg.solve(L.T, v)
+
+        self._cache = _FitCache(
+            X_train_scaled=X_scaled,
+            y_mean=y_mean,
+            y_std=y_std,
+            L=L,
+            alpha=alpha,
+            signal_var=self.signal_var,
+            noise_var=self.noise_var,
+            jitter=self.jitter,
+            length_scales=self.length_scales.copy(),
+        )
+
+        logger.debug(
+            "MaternGP fit: n=%d, y_mean=%.2f, y_std=%.4f, diag_add=%.2e",
+            n, y_mean, y_std, diag_add,
+        )
+
+    # ------------------------------------------------------------------
+    # predict
+    # ------------------------------------------------------------------
+    def predict(
+        self,
+        X_pred: NDArray,
+        return_std: bool = True,
+    ) -> Tuple[NDArray, Optional[NDArray]]:
+        """
+        Predict at new locations.
+
+        Args:
+            X_pred: (m, d) prediction inputs, X-normalized by caller.
+            return_std: If True, also return posterior std of latent f.
+
+        Returns:
+            mean: (m,) posterior mean in original y scale.
+            std:  (m,) posterior std of latent function f (or None).
+                  For observation-level: std_y = sqrt(std**2 + noise_var).
+        """
+        if self._cache is None:
+            raise RuntimeError("MaternGP.predict() called before fit()")
+
+        c = self._cache
+        X_pred = np.asarray(X_pred, dtype=np.float64)
+
+        # -- Scale prediction inputs --
+        X_pred_scaled = X_pred / c.length_scales  # (m, d)
+
+        # -- Cross-covariance K(X*, X_train) --
+        D2_star = _scaled_sqdist(X_pred_scaled, c.X_train_scaled)
+        r_star = np.sqrt(D2_star)
+        K_star = _matern52(r_star, c.signal_var)  # (m, n)
+
+        # -- Posterior mean (normalized space) --
+        mean_norm = K_star @ c.alpha  # (m,)
+
+        # -- Un-normalize --
+        mean = mean_norm * c.y_std + c.y_mean
+
+        if not return_std:
+            return mean, None
+
+        # -- Posterior variance of f --
+        # w = L^{-1} K_star^T  →  shape (n, m)
+        w = np.linalg.solve(c.L, K_star.T)
+
+        # k(x*,x*) diagonal = signal_var (Matérn at r=0)
+        k_ss = c.signal_var
+
+        # var_f = k_ss - sum(w^2, axis=0)
+        var_f = k_ss - np.sum(w * w, axis=0)  # (m,)
+        np.maximum(var_f, 0.0, out=var_f)
+
+        # Scale std back to original y space
+        std = np.sqrt(var_f) * c.y_std
+
+        return mean, std
+
+    # ------------------------------------------------------------------
+    # Invalidation
+    # ------------------------------------------------------------------
+    def invalidate(self) -> None:
+        """Clear cached factorization. Call when training data changes."""
+        self._cache = None
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+    def get_hyperparameters(self) -> dict:
+        """Return current frozen hyperparameters for logging/auditing."""
+        return {
+            "length_scales": self.length_scales.tolist(),
+            "signal_var": self.signal_var,
+            "noise_var": self.noise_var,
+            "jitter": self.jitter,
+            "normalize_y": self.normalize_y,
+        }
+
+

--- a/dynoai/core/gp_engine.py
+++ b/dynoai/core/gp_engine.py
@@ -39,9 +39,9 @@ logger = logging.getLogger(__name__)
 # These are seed values matching the sklearn kernel's initial config.
 # They must be validated via holdout harness before production use.
 DEFAULT_LENGTH_SCALES = np.array([0.3, 0.3], dtype=np.float64)
-DEFAULT_SIGNAL_VAR = 1.0     # No ConstantKernel in current sklearn config
-DEFAULT_NOISE_VAR = 0.15     # WhiteKernel(0.1) + alpha(0.05) combined
-DEFAULT_JITTER = 1e-8        # Numerical stability only
+DEFAULT_SIGNAL_VAR = 1.0  # No ConstantKernel in current sklearn config
+DEFAULT_NOISE_VAR = 0.15  # WhiteKernel(0.1) + alpha(0.05) combined
+DEFAULT_JITTER = 1e-8  # Numerical stability only
 
 
 # ---------------------------------------------------------------------------
@@ -90,11 +90,11 @@ def _matern52(r: NDArray, signal_var: float = 1.0) -> NDArray:
 class _FitCache:
     """Cached Cholesky factorization and solve results from fit()."""
 
-    X_train_scaled: NDArray          # (n, d) — pre-divided by length_scales
-    y_mean: float                    # center of y normalization
-    y_std: float                     # scale of y normalization
-    L: NDArray                       # (n, n) — lower Cholesky of K + noise*I
-    alpha: NDArray                   # (n,) or (n, 1) — K^{-1} y_norm
+    X_train_scaled: NDArray  # (n, d) — pre-divided by length_scales
+    y_mean: float  # center of y normalization
+    y_std: float  # scale of y normalization
+    L: NDArray  # (n, n) — lower Cholesky of K + noise*I
+    alpha: NDArray  # (n,) or (n, 1) — K^{-1} y_norm
     signal_var: float
     noise_var: float
     jitter: float
@@ -222,7 +222,10 @@ class MaternGP:
 
         logger.debug(
             "MaternGP fit: n=%d, y_mean=%.2f, y_std=%.4f, diag_add=%.2e",
-            n, y_mean, y_std, diag_add,
+            n,
+            y_mean,
+            y_std,
+            diag_add,
         )
 
     # ------------------------------------------------------------------
@@ -303,5 +306,3 @@ class MaternGP:
             "jitter": self.jitter,
             "normalize_y": self.normalize_y,
         }
-
-

--- a/dynoai_v3/gp_surrogate.py
+++ b/dynoai_v3/gp_surrogate.py
@@ -39,6 +39,13 @@ from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# GP backend selection
+# ---------------------------------------------------------------------------
+# "sklearn" = original GaussianProcessRegressor with optimizer (default)
+# "numpy"   = pure-NumPy MaternGP with frozen hyperparameters (deterministic)
+GP_BACKEND: str = "numpy"
+
 # Extreme VE value threshold — observations beyond reasonable VE range are rejected
 # Typical VE range is 60-120%, so values outside ±50% from 85% mean are suspicious
 _MAX_VE_DEVIATION = 50.0  # Reject if |VE - 85| > 50 (i.e., VE < 35 or VE > 135)
@@ -164,10 +171,12 @@ class VESurrogate:
         rpm_bins: NDArray[np.float64],
         map_bins: NDArray[np.float64],
         engine_family: str,
+        backend: Optional[str] = None,
     ):
         self.rpm_bins = np.array(rpm_bins, dtype=np.float64)
         self.map_bins = np.array(map_bins, dtype=np.float64)
         self.engine_family = engine_family
+        self._backend = backend or GP_BACKEND
         self.observations: List[Observation] = []
         self.template_observation_count: int = 0
         
@@ -186,8 +195,8 @@ class VESurrogate:
         self._map_range = float(np.max(map_bins) - np.min(map_bins))
 
         logger.info(
-            "VESurrogate initialized: %s, %d RPM bins x %d MAP bins",
-            engine_family, len(rpm_bins), len(map_bins),
+            "VESurrogate initialized: %s, %d RPM bins x %d MAP bins, backend=%s",
+            engine_family, len(rpm_bins), len(map_bins), self._backend,
         )
 
     # ------------------------------------------------------------------
@@ -430,17 +439,19 @@ class VESurrogate:
                     predict_time_ms=elapsed,
                 )
 
-        # Guard: sklearn 1.8+ can leave GPR without alpha_ after fit in edge cases
-        if not hasattr(self._gp_model, "alpha_") or self._gp_model.alpha_ is None:
-            logger.warning("GP model not properly fitted (missing alpha_); returning prior")
-            elapsed = (time.time() - t0) * 1000
-            unc_map = np.full((n_rpm, n_map), 10.0)
-            return FullMapPrediction(
-                ve_map=np.zeros((n_rpm, n_map)),
-                uncertainty_map=unc_map,
-                confidence_map=_uncertainty_map_to_confidence(unc_map),
-                predict_time_ms=elapsed,
-            )
+        # Guard: sklearn 1.8+ can leave GPR without alpha_ after fit in edge cases.
+        # NumPy backend doesn't have this issue (deterministic Cholesky path).
+        if self._backend == "sklearn":
+            if not hasattr(self._gp_model, "alpha_") or self._gp_model.alpha_ is None:
+                logger.warning("GP model not properly fitted (missing alpha_); returning prior")
+                elapsed = (time.time() - t0) * 1000
+                unc_map = np.full((n_rpm, n_map), 10.0)
+                return FullMapPrediction(
+                    ve_map=np.zeros((n_rpm, n_map)),
+                    uncertainty_map=unc_map,
+                    confidence_map=_uncertainty_map_to_confidence(unc_map),
+                    predict_time_ms=elapsed,
+                )
 
         # Build an (n_rpm*n_map, 2) grid without Python loops.
         rr, mm = np.meshgrid(self.rpm_bins, self.map_bins, indexing="ij")
@@ -476,10 +487,11 @@ class VESurrogate:
         Uses at most _MAX_OBS_FOR_REFIT total points to keep fit time bounded.
         Template observations (pull_number == -1) are always retained in the fit
         so template priors are not lost.
-        """
-        from sklearn.gaussian_process import GaussianProcessRegressor
-        from sklearn.gaussian_process.kernels import Matern, WhiteKernel
 
+        Backend selection:
+            "sklearn" — GaussianProcessRegressor with optimizer (original)
+            "numpy"   — Pure NumPy MaternGP with frozen hyperparameters
+        """
         if len(self.observations) < 3:
             return
 
@@ -504,6 +516,28 @@ class VESurrogate:
 
         X_norm = self._normalize(X)
 
+        if self._backend == "numpy":
+            self._refit_numpy(X_norm, y)
+        else:
+            self._refit_sklearn(X_norm, y)
+
+        self.is_fitted = True
+        self._stale = False
+
+        self._last_fit_time_ms = (time.time() - t0) * 1000
+        logger.info(
+            "GP refit [%s]: %d used (of %d total), %.1f ms",
+            self._backend,
+            n_used,
+            len(self.observations),
+            self._last_fit_time_ms,
+        )
+
+    def _refit_sklearn(self, X_norm: NDArray, y: NDArray) -> None:
+        """Fit using sklearn GaussianProcessRegressor (original path)."""
+        from sklearn.gaussian_process import GaussianProcessRegressor
+        from sklearn.gaussian_process.kernels import Matern, WhiteKernel
+
         # Create fresh kernel for each fit
         # Note: Warm-start kernel copying causes issues with sklearn 1.8+
         # (missing alpha_ attribute after prediction). Fresh fit is fast enough
@@ -520,16 +554,19 @@ class VESurrogate:
             normalize_y=True,
         )
         self._gp_model.fit(X_norm, y)
-        self.is_fitted = True
-        self._stale = False
 
-        self._last_fit_time_ms = (time.time() - t0) * 1000
-        logger.info(
-            "GP refit: %d used (of %d total), %.1f ms",
-            n_used,
-            len(self.observations),
-            self._last_fit_time_ms,
+    def _refit_numpy(self, X_norm: NDArray, y: NDArray) -> None:
+        """Fit using pure NumPy MaternGP (deterministic, frozen hyperparameters)."""
+        from dynoai.core.gp_engine import MaternGP
+
+        self._gp_model = MaternGP(
+            length_scales=np.array([0.3, 0.3]),
+            signal_var=1.0,
+            noise_var=0.15,
+            jitter=1e-8,
+            normalize_y=True,
         )
+        self._gp_model.fit(X_norm, y)
 
     # ------------------------------------------------------------------
     # Normalization
@@ -553,6 +590,7 @@ class VESurrogate:
             "rpm_bins": self.rpm_bins.tolist(),
             "map_bins": self.map_bins.tolist(),
             "template_observation_count": self.template_observation_count,
+            "gp_backend": self._backend,
             "observations": [
                 {
                     "rpm": o.rpm,
@@ -581,7 +619,8 @@ class VESurrogate:
 
         rpm_bins = np.array(state["rpm_bins"], dtype=np.float64)
         map_bins = np.array(state["map_bins"], dtype=np.float64)
-        s = cls(rpm_bins, map_bins, state["engine_family"])
+        backend = state.get("gp_backend", GP_BACKEND)
+        s = cls(rpm_bins, map_bins, state["engine_family"], backend=backend)
         s.template_observation_count = state.get("template_observation_count", 0)
 
         for od in state["observations"]:

--- a/dynoai_v3/gp_surrogate.py
+++ b/dynoai_v3/gp_surrogate.py
@@ -70,12 +70,12 @@ def uncertainty_to_confidence(std: float) -> float:
     Aligns with existing H/M/L/skip badge system.
     """
     if std < 0.5:
-        return 95.0   # High
+        return 95.0  # High
     if std < 1.0:
-        return 80.0   # Medium
+        return 80.0  # Medium
     if std < 2.0:
-        return 60.0   # Low
-    return 20.0        # Skip / insufficient
+        return 60.0  # Low
+    return 20.0  # Skip / insufficient
 
 
 def confidence_to_badge(confidence: float) -> str:
@@ -114,10 +114,11 @@ def _uncertainty_map_to_confidence(unc_map: NDArray[np.float64]) -> NDArray[np.f
 @dataclass
 class Observation:
     """A single measured data point from a dyno pull.
-    
+
     Note: Despite the field name 've_delta', this stores absolute VE percentage values
     (70-113%), not deltas. The naming is historical but the semantics are absolute VE.
     """
+
     rpm: float
     map_kpa: float
     ve_delta: float  # Absolute VE percentage (e.g., 85.5%)
@@ -128,9 +129,10 @@ class Observation:
 @dataclass
 class PointPrediction:
     """Prediction at a single operating point.
-    
+
     Note: ve_delta stores absolute VE percentage (70-113%), not a delta.
     """
+
     ve_delta: float  # Absolute VE percentage (e.g., 92.3%)
     uncertainty: float
     confidence: float
@@ -140,9 +142,10 @@ class PointPrediction:
 @dataclass
 class FullMapPrediction:
     """Prediction across the entire VE grid.
-    
+
     Note: ve_map contains absolute VE percentages (70-113%), not deltas.
     """
+
     ve_map: NDArray[np.float64]  # Absolute VE percentages
     uncertainty_map: NDArray[np.float64]
     confidence_map: NDArray[np.float64]
@@ -179,7 +182,7 @@ class VESurrogate:
         self._backend = backend or GP_BACKEND
         self.observations: List[Observation] = []
         self.template_observation_count: int = 0
-        
+
         # Store raw seed VE table for exact 1:1 reproduction (PVV import)
         self._seed_ve_table: Optional[NDArray[np.float64]] = None
 
@@ -196,7 +199,10 @@ class VESurrogate:
 
         logger.info(
             "VESurrogate initialized: %s, %d RPM bins x %d MAP bins, backend=%s",
-            engine_family, len(rpm_bins), len(map_bins), self._backend,
+            engine_family,
+            len(rpm_bins),
+            len(map_bins),
+            self._backend,
         )
 
     # ------------------------------------------------------------------
@@ -275,16 +281,20 @@ class VESurrogate:
             if abs(ve[i] - 85.0) > _MAX_VE_DEVIATION:
                 logger.debug(
                     "Rejected extreme VE value: %.2f%% at RPM=%.0f MAP=%.0f",
-                    ve[i], rpm[i], map_kpa[i],
+                    ve[i],
+                    rpm[i],
+                    map_kpa[i],
                 )
                 continue
-            self.observations.append(Observation(
-                rpm=float(rpm[i]),
-                map_kpa=float(map_kpa[i]),
-                ve_delta=float(ve[i]),  # Stores absolute VE %
-                pull_number=pull_number,
-                timestamp=ts,
-            ))
+            self.observations.append(
+                Observation(
+                    rpm=float(rpm[i]),
+                    map_kpa=float(map_kpa[i]),
+                    ve_delta=float(ve[i]),  # Stores absolute VE %
+                    pull_number=pull_number,
+                    timestamp=ts,
+                )
+            )
             accepted += 1
 
         if accepted > 0:
@@ -293,7 +303,8 @@ class VESurrogate:
 
         logger.info(
             "Pull data ingested: %d/%d accepted (pull #%s)",
-            accepted, len(rpm),
+            accepted,
+            len(rpm),
             pull_number if pull_number is not None else "?",
         )
         return accepted
@@ -322,10 +333,10 @@ class VESurrogate:
         template_ve = np.asarray(template_ve, dtype=np.float64)
         rpm_bins = np.asarray(rpm_bins, dtype=np.float64)
         map_bins = np.asarray(map_bins, dtype=np.float64)
-        
+
         # Store raw seed table for exact 1:1 reproduction when no real pulls exist
         self._seed_ve_table = template_ve.copy()
-        
+
         logger.info(
             "Storing seed VE table: shape=%s, min=%.1f%%, max=%.1f%%, mean=%.1f%%",
             self._seed_ve_table.shape,
@@ -339,13 +350,15 @@ class VESurrogate:
         for r_idx, rpm in enumerate(rpm_bins):
             for m_idx, map_kpa in enumerate(map_bins):
                 if r_idx < template_ve.shape[0] and m_idx < template_ve.shape[1]:
-                    self.observations.append(Observation(
-                        rpm=float(rpm),
-                        map_kpa=float(map_kpa),
-                        ve_delta=float(template_ve[r_idx, m_idx]),
-                        pull_number=-1,  # Sentinel for template data
-                        timestamp=ts,
-                    ))
+                    self.observations.append(
+                        Observation(
+                            rpm=float(rpm),
+                            map_kpa=float(map_kpa),
+                            ve_delta=float(template_ve[r_idx, m_idx]),
+                            pull_number=-1,  # Sentinel for template data
+                            timestamp=ts,
+                        )
+                    )
                     count += 1
 
         self.template_observation_count = count
@@ -355,7 +368,8 @@ class VESurrogate:
             self._stale = True
 
         logger.info(
-            "Template seeded: %d synthetic observations added", count,
+            "Template seeded: %d synthetic observations added",
+            count,
         )
 
     # ------------------------------------------------------------------
@@ -415,15 +429,17 @@ class VESurrogate:
             )
 
         # If we only have template data, return raw seed values for accuracy
-        if hasattr(self, '_seed_ve_table') and self._seed_ve_table is not None:
+        if hasattr(self, "_seed_ve_table") and self._seed_ve_table is not None:
             all_template = all(o.pull_number == -1 for o in self.observations)
             if all_template and self._seed_ve_table.shape == (n_rpm, n_map):
                 # Use constant uncertainty (no GP predict) to avoid sklearn 1.8+
                 # AttributeError when alpha_ is not set after fit
-                unc_map = np.full((n_rpm, n_map), 1.0)  # Medium uncertainty until real pulls
+                unc_map = np.full(
+                    (n_rpm, n_map), 1.0
+                )  # Medium uncertainty until real pulls
                 conf_map = _uncertainty_map_to_confidence(unc_map)
                 elapsed = (time.time() - t0) * 1000
-                
+
                 logger.info(
                     "Returning raw seed VE table (template-only, no real pulls): "
                     "shape=%s, min=%.1f%%, max=%.1f%%, mean=%.1f%%",
@@ -443,7 +459,9 @@ class VESurrogate:
         # NumPy backend doesn't have this issue (deterministic Cholesky path).
         if self._backend == "sklearn":
             if not hasattr(self._gp_model, "alpha_") or self._gp_model.alpha_ is None:
-                logger.warning("GP model not properly fitted (missing alpha_); returning prior")
+                logger.warning(
+                    "GP model not properly fitted (missing alpha_); returning prior"
+                )
                 elapsed = (time.time() - t0) * 1000
                 unc_map = np.full((n_rpm, n_map), 10.0)
                 return FullMapPrediction(
@@ -542,9 +560,7 @@ class VESurrogate:
         # Note: Warm-start kernel copying causes issues with sklearn 1.8+
         # (missing alpha_ attribute after prediction). Fresh fit is fast enough
         # with sklearn 1.8.0 and avoids compatibility issues.
-        kernel = Matern(nu=2.5, length_scale=[0.3, 0.3]) + WhiteKernel(
-            noise_level=0.1
-        )
+        kernel = Matern(nu=2.5, length_scale=[0.3, 0.3]) + WhiteKernel(noise_level=0.1)
         n_restarts = 2
 
         self._gp_model = GaussianProcessRegressor(
@@ -608,7 +624,8 @@ class VESurrogate:
             json.dump(state, f, indent=2)
         logger.info(
             "GP state saved to %s (%d observations)",
-            path, len(self.observations),
+            path,
+            len(self.observations),
         )
 
     @classmethod
@@ -624,13 +641,15 @@ class VESurrogate:
         s.template_observation_count = state.get("template_observation_count", 0)
 
         for od in state["observations"]:
-            s.observations.append(Observation(
-                rpm=od["rpm"],
-                map_kpa=od["map_kpa"],
-                ve_delta=od["ve_delta"],
-                pull_number=od.get("pull_number"),
-                timestamp=od.get("timestamp"),
-            ))
+            s.observations.append(
+                Observation(
+                    rpm=od["rpm"],
+                    map_kpa=od["map_kpa"],
+                    ve_delta=od["ve_delta"],
+                    pull_number=od.get("pull_number"),
+                    timestamp=od.get("timestamp"),
+                )
+            )
 
         if len(s.observations) >= 3:
             s._refit()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3881,17 +3881,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.54.0.tgz",
-            "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+            "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.54.0",
-                "@typescript-eslint/type-utils": "8.54.0",
-                "@typescript-eslint/utils": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
+                "@typescript-eslint/scope-manager": "8.56.0",
+                "@typescript-eslint/type-utils": "8.56.0",
+                "@typescript-eslint/utils": "8.56.0",
+                "@typescript-eslint/visitor-keys": "8.56.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.4.0"
@@ -3904,8 +3904,8 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.54.0",
-                "eslint": "^8.57.0 || ^9.0.0",
+                "@typescript-eslint/parser": "^8.56.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
@@ -3920,17 +3920,17 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
-            "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+            "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
+                "@typescript-eslint/scope-manager": "8.56.0",
+                "@typescript-eslint/types": "8.56.0",
+                "@typescript-eslint/typescript-estree": "8.56.0",
+                "@typescript-eslint/visitor-keys": "8.56.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3941,19 +3941,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
-            "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+            "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.54.0",
-                "@typescript-eslint/types": "^8.54.0",
+                "@typescript-eslint/tsconfig-utils": "^8.56.0",
+                "@typescript-eslint/types": "^8.56.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3968,14 +3968,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
-            "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+            "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0"
+                "@typescript-eslint/types": "8.56.0",
+                "@typescript-eslint/visitor-keys": "8.56.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3986,9 +3986,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
-            "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+            "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4003,15 +4003,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
-            "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+            "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0",
-                "@typescript-eslint/utils": "8.54.0",
+                "@typescript-eslint/types": "8.56.0",
+                "@typescript-eslint/typescript-estree": "8.56.0",
+                "@typescript-eslint/utils": "8.56.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.4.0"
             },
@@ -4023,14 +4023,14 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
-            "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+            "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4042,16 +4042,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
-            "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+            "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.54.0",
-                "@typescript-eslint/tsconfig-utils": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
+                "@typescript-eslint/project-service": "8.56.0",
+                "@typescript-eslint/tsconfig-utils": "8.56.0",
+                "@typescript-eslint/types": "8.56.0",
+                "@typescript-eslint/visitor-keys": "8.56.0",
                 "debug": "^4.4.3",
                 "minimatch": "^9.0.5",
                 "semver": "^7.7.3",
@@ -4109,16 +4109,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
-            "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+            "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0"
+                "@typescript-eslint/scope-manager": "8.56.0",
+                "@typescript-eslint/types": "8.56.0",
+                "@typescript-eslint/typescript-estree": "8.56.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4128,19 +4128,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
-            "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+            "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "eslint-visitor-keys": "^4.2.1"
+                "@typescript-eslint/types": "8.56.0",
+                "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4148,6 +4148,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+            "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@vitejs/plugin-react": {
@@ -4275,13 +4288,13 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-            "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+            "version": "1.13.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
                 "proxy-from-env": "^1.1.0"
             }
         },
@@ -7201,16 +7214,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.54.0.tgz",
-            "integrity": "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==",
+            "version": "8.56.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
+            "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.54.0",
-                "@typescript-eslint/parser": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0",
-                "@typescript-eslint/utils": "8.54.0"
+                "@typescript-eslint/eslint-plugin": "8.56.0",
+                "@typescript-eslint/parser": "8.56.0",
+                "@typescript-eslint/typescript-estree": "8.56.0",
+                "@typescript-eslint/utils": "8.56.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7220,7 +7233,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,4 +34,7 @@ def pytest_configure(config):
     if str(PROJECT_ROOT) not in sys.path:
         sys.path.insert(0, str(PROJECT_ROOT))
     # Register custom markers
-    config.addinivalue_line("markers", "validation: heavy holdout/parity tests (deselect with -m 'not validation')")
+    config.addinivalue_line(
+        "markers",
+        "validation: heavy holdout/parity tests (deselect with -m 'not validation')",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,12 @@ os.environ["JETSTREAM_STUB_MODE"] = "true"
 os.environ["JETSTREAM_ENABLED"] = "false"
 # CRITICAL: Disable rate limiting for tests
 os.environ["RATE_LIMIT_ENABLED"] = "false"
+# Pin BLAS/OpenMP threads for GP determinism (NumPy Cholesky, solve)
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
 
 
 def pytest_configure(config):
@@ -27,3 +33,5 @@ def pytest_configure(config):
     # Ensure path is set for all pytest operations
     if str(PROJECT_ROOT) not in sys.path:
         sys.path.insert(0, str(PROJECT_ROOT))
+    # Register custom markers
+    config.addinivalue_line("markers", "validation: heavy holdout/parity tests (deselect with -m 'not validation')")

--- a/tests/test_gp_engine_parity.py
+++ b/tests/test_gp_engine_parity.py
@@ -82,7 +82,7 @@ def _sklearn_fixed_predict(X_train, y_train, X_pred, return_std=True):
         kernel=kernel,
         n_restarts_optimizer=0,
         optimizer=None,  # Fully disable optimizer
-        alpha=JITTER,    # Only jitter on diagonal (noise is in WhiteKernel)
+        alpha=JITTER,  # Only jitter on diagonal (noise is in WhiteKernel)
         normalize_y=True,
     )
     gp.fit(X_train, y_train)
@@ -128,8 +128,10 @@ class TestMathParity:
         max_diff = float(np.max(np.abs(mean_sk - mean_np)))
         mae = float(np.mean(np.abs(mean_sk - mean_np)))
 
-        print(f"\n  Mean parity [{grid_name}, n={n_train}]: "
-              f"max_diff={max_diff:.2e}, MAE={mae:.2e}")
+        print(
+            f"\n  Mean parity [{grid_name}, n={n_train}]: "
+            f"max_diff={max_diff:.2e}, MAE={mae:.2e}"
+        )
 
         # Tight tolerance — this is the same math, just different implementation
         assert max_diff < 1e-6, (
@@ -165,8 +167,10 @@ class TestMathParity:
         std_np_observation = np.sqrt(std_np**2 + NOISE_VAR * y_std_val**2)
 
         max_diff = float(np.max(np.abs(std_sk - std_np_observation)))
-        print(f"\n  Std parity [{grid_name}, n={n_train}]: "
-              f"max_diff={max_diff:.2e} (after noise correction)")
+        print(
+            f"\n  Std parity [{grid_name}, n={n_train}]: "
+            f"max_diff={max_diff:.2e} (after noise correction)"
+        )
 
         # After accounting for the noise term, should match tightly
         assert max_diff < 1e-4, (
@@ -175,8 +179,10 @@ class TestMathParity:
 
         # Also verify the raw difference matches expected noise contribution
         raw_diff = float(np.max(np.abs(std_sk - std_np)))
-        print(f"  Raw std diff (before correction): {raw_diff:.4f} "
-              f"(expected ~sqrt(noise_var)*y_std = {np.sqrt(NOISE_VAR)*y_std_val:.4f})")
+        print(
+            f"  Raw std diff (before correction): {raw_diff:.4f} "
+            f"(expected ~sqrt(noise_var)*y_std = {np.sqrt(NOISE_VAR) * y_std_val:.4f})"
+        )
 
 
 class TestNumpyDeterminism:
@@ -205,7 +211,9 @@ class TestNumpyDeterminism:
         for i in range(1, len(results)):
             mean_diff = float(np.max(np.abs(results[0][0] - results[i][0])))
             std_diff = float(np.max(np.abs(results[0][1] - results[i][1])))
-            print(f"\n  Trial 0 vs {i}: mean_diff={mean_diff:.2e}, std_diff={std_diff:.2e}")
+            print(
+                f"\n  Trial 0 vs {i}: mean_diff={mean_diff:.2e}, std_diff={std_diff:.2e}"
+            )
             assert mean_diff == 0.0, f"Mean not bit-identical: diff={mean_diff}"
             assert std_diff == 0.0, f"Std not bit-identical: diff={std_diff}"
 
@@ -221,7 +229,9 @@ class TestNumpyLatency:
         """fit() must complete within budget."""
         X_train, y_train = _make_training_data(n_train)
 
-        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp = MaternGP(
+            length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR
+        )
 
         timings = []
         for _ in range(10):
@@ -231,8 +241,10 @@ class TestNumpyLatency:
             timings.append((time.perf_counter() - t0) * 1000)
 
         median_ms = float(np.median(timings))
-        print(f"\n  Fit latency [n={n_train}]: median={median_ms:.2f}ms, "
-              f"all={[f'{t:.2f}' for t in timings]}")
+        print(
+            f"\n  Fit latency [n={n_train}]: median={median_ms:.2f}ms, "
+            f"all={[f'{t:.2f}' for t in timings]}"
+        )
 
         # Contract: < 10ms for ≤ 150 points
         assert median_ms < 10.0, f"Fit too slow: {median_ms:.2f}ms (budget: 10ms)"
@@ -245,7 +257,9 @@ class TestNumpyLatency:
         rpm_norm, map_norm = GRID_SHAPES[grid_name]
         X_pred = _make_pred_grid(rpm_norm, map_norm)
 
-        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp = MaternGP(
+            length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR
+        )
         gp.fit(X_train, y_train)
 
         timings = []
@@ -256,8 +270,10 @@ class TestNumpyLatency:
 
         median_ms = float(np.median(timings))
         n_pred = X_pred.shape[0]
-        print(f"\n  Predict latency [{grid_name}, n_train={n_train}, n_pred={n_pred}]: "
-              f"median={median_ms:.2f}ms")
+        print(
+            f"\n  Predict latency [{grid_name}, n_train={n_train}, n_pred={n_pred}]: "
+            f"median={median_ms:.2f}ms"
+        )
 
         # Contract: < 2ms for cached prediction
         assert median_ms < 2.0, f"Predict too slow: {median_ms:.2f}ms (budget: 2ms)"
@@ -273,7 +289,9 @@ class TestEdgeCases:
         X = np.array([[0.5, 0.5]])
         y = np.array([90.0])
 
-        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp = MaternGP(
+            length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR
+        )
         gp.fit(X, y)
 
         X_pred = np.array([[0.5, 0.5], [0.0, 0.0], [1.0, 1.0]])
@@ -290,7 +308,9 @@ class TestEdgeCases:
         X = np.random.RandomState(42).rand(20, 2)
         y = np.full(20, 85.0)
 
-        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp = MaternGP(
+            length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR
+        )
         gp.fit(X, y)
 
         X_pred = np.array([[0.5, 0.5]])
@@ -345,7 +365,9 @@ class TestEdgeCases:
         map_norm = np.linspace(0, 1, 32)
         X_pred = _make_pred_grid(rpm_norm, map_norm)
 
-        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp = MaternGP(
+            length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR
+        )
         gp.fit(X_train, y_train)
         mean, std = gp.predict(X_pred)
 

--- a/tests/test_gp_engine_parity.py
+++ b/tests/test_gp_engine_parity.py
@@ -1,0 +1,355 @@
+"""
+DynoAI GP Engine — Parity Tests
+=================================
+
+A/B comparison of MaternGP (NumPy) vs sklearn GaussianProcessRegressor
+with optimizer DISABLED (fixed kernel params).
+
+This isolates the math comparison from sklearn's optimizer behavior.
+Both backends get the same X, y, and hyperparameters.
+
+Run:  pytest tests/test_gp_engine_parity.py -v -s
+
+Author: Thunderhorse Tuning / DynoAI
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from dynoai.core.gp_engine import MaternGP
+
+# ---------------------------------------------------------------------------
+# Shared test data generators (deterministic)
+# ---------------------------------------------------------------------------
+GRID_SHAPES = {
+    "10x9": (
+        np.linspace(0, 1, 10),  # Already normalized
+        np.linspace(0, 1, 9),
+    ),
+    "11x5": (
+        np.linspace(0, 1, 11),
+        np.linspace(0, 1, 5),
+    ),
+    "16x16": (
+        np.linspace(0, 1, 16),
+        np.linspace(0, 1, 16),
+    ),
+}
+
+
+def _make_training_data(n: int, d: int = 2, seed: int = 42):
+    """Generate normalized training data in [0,1]^d with smooth target."""
+    rng = np.random.RandomState(seed)
+    X = rng.rand(n, d)
+    # Smooth target: y = 85 + 10*sin(pi*x0) + 15*x1 + noise
+    y = 85.0 + 10.0 * np.sin(np.pi * X[:, 0]) + 15.0 * X[:, 1] + rng.randn(n) * 0.5
+    return X, y
+
+
+def _make_pred_grid(rpm_norm: np.ndarray, map_norm: np.ndarray) -> np.ndarray:
+    """Create prediction grid from normalized axes."""
+    rr, mm = np.meshgrid(rpm_norm, map_norm, indexing="ij")
+    return np.column_stack([rr.ravel(), mm.ravel()])
+
+
+# ---------------------------------------------------------------------------
+# Frozen hyperparameters for parity comparison
+# ---------------------------------------------------------------------------
+LENGTH_SCALES = np.array([0.3, 0.3])
+SIGNAL_VAR = 1.0
+NOISE_VAR = 0.15  # Combined: WhiteKernel(0.1) + alpha(0.05)
+JITTER = 1e-8
+
+
+def _sklearn_fixed_predict(X_train, y_train, X_pred, return_std=True):
+    """
+    sklearn GP with optimizer DISABLED and matching hyperparameters.
+
+    This is the apples-to-apples comparison target.
+    """
+    from sklearn.gaussian_process import GaussianProcessRegressor
+    from sklearn.gaussian_process.kernels import Matern, WhiteKernel
+
+    # Fixed kernel (n_restarts_optimizer=0 disables optimization)
+    kernel = Matern(nu=2.5, length_scale=LENGTH_SCALES.tolist()) + WhiteKernel(
+        noise_level=NOISE_VAR
+    )
+    gp = GaussianProcessRegressor(
+        kernel=kernel,
+        n_restarts_optimizer=0,
+        optimizer=None,  # Fully disable optimizer
+        alpha=JITTER,    # Only jitter on diagonal (noise is in WhiteKernel)
+        normalize_y=True,
+    )
+    gp.fit(X_train, y_train)
+    if return_std:
+        mean, std = gp.predict(X_pred, return_std=True)
+        return mean, std
+    return gp.predict(X_pred), None
+
+
+def _numpy_predict(X_train, y_train, X_pred, return_std=True):
+    """NumPy GP with matching hyperparameters."""
+    gp = MaternGP(
+        length_scales=LENGTH_SCALES,
+        signal_var=SIGNAL_VAR,
+        noise_var=NOISE_VAR,
+        jitter=JITTER,
+        normalize_y=True,
+    )
+    gp.fit(X_train, y_train)
+    mean, std = gp.predict(X_pred, return_std=return_std)
+    return mean, std
+
+
+# ===========================================================================
+# Parity tests
+# ===========================================================================
+class TestMathParity:
+    """Verify NumPy engine produces same results as sklearn with fixed params."""
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("n_train", [10, 50, 120])
+    @pytest.mark.parametrize("grid_name", ["11x5", "16x16"])
+    def test_mean_parity(self, n_train, grid_name):
+        """Posterior mean should match within tight tolerance."""
+        X_train, y_train = _make_training_data(n_train)
+        rpm_norm, map_norm = GRID_SHAPES[grid_name]
+        X_pred = _make_pred_grid(rpm_norm, map_norm)
+
+        mean_sk, _ = _sklearn_fixed_predict(X_train, y_train, X_pred, return_std=False)
+        mean_np, _ = _numpy_predict(X_train, y_train, X_pred, return_std=False)
+
+        max_diff = float(np.max(np.abs(mean_sk - mean_np)))
+        mae = float(np.mean(np.abs(mean_sk - mean_np)))
+
+        print(f"\n  Mean parity [{grid_name}, n={n_train}]: "
+              f"max_diff={max_diff:.2e}, MAE={mae:.2e}")
+
+        # Tight tolerance — this is the same math, just different implementation
+        assert max_diff < 1e-6, (
+            f"Mean parity failed: max_diff={max_diff:.2e} (tolerance: 1e-6)"
+        )
+
+    @pytest.mark.parametrize("n_train", [10, 50, 120])
+    @pytest.mark.parametrize("grid_name", ["11x5", "16x16"])
+    def test_std_parity(self, n_train, grid_name):
+        """Posterior std should match after accounting for noise semantics.
+
+        sklearn's kernel (Matern + WhiteKernel) includes noise_var in the prior
+        diagonal at prediction points:  k_ss_sklearn = signal_var + noise_var.
+        NumPy engine returns latent std: k_ss_numpy = signal_var.
+
+        Relationship: std_sklearn² = std_numpy² + noise_var * y_std²
+        We verify this holds to numerical precision.
+        """
+        X_train, y_train = _make_training_data(n_train)
+        rpm_norm, map_norm = GRID_SHAPES[grid_name]
+        X_pred = _make_pred_grid(rpm_norm, map_norm)
+
+        _, std_sk = _sklearn_fixed_predict(X_train, y_train, X_pred)
+        _, std_np = _numpy_predict(X_train, y_train, X_pred)
+
+        # Compute y_std for the noise_var un-normalization factor
+        y_std_val = float(np.std(y_train))
+        if y_std_val < 1e-12:
+            y_std_val = 1.0
+
+        # Convert numpy latent std to observation std for comparison
+        # var_observation = var_latent + noise_var * y_std²
+        std_np_observation = np.sqrt(std_np**2 + NOISE_VAR * y_std_val**2)
+
+        max_diff = float(np.max(np.abs(std_sk - std_np_observation)))
+        print(f"\n  Std parity [{grid_name}, n={n_train}]: "
+              f"max_diff={max_diff:.2e} (after noise correction)")
+
+        # After accounting for the noise term, should match tightly
+        assert max_diff < 1e-4, (
+            f"Std parity failed: max_diff={max_diff:.2e} (tolerance: 1e-4)"
+        )
+
+        # Also verify the raw difference matches expected noise contribution
+        raw_diff = float(np.max(np.abs(std_sk - std_np)))
+        print(f"  Raw std diff (before correction): {raw_diff:.4f} "
+              f"(expected ~sqrt(noise_var)*y_std = {np.sqrt(NOISE_VAR)*y_std_val:.4f})")
+
+
+class TestNumpyDeterminism:
+    """Verify NumPy engine is bit-identical across repeated calls."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_bit_identical_repeated_fit_predict(self):
+        """Same inputs → same outputs, exactly."""
+        X_train, y_train = _make_training_data(80)
+        rpm_norm, map_norm = GRID_SHAPES["16x16"]
+        X_pred = _make_pred_grid(rpm_norm, map_norm)
+
+        results = []
+        for _ in range(5):
+            gp = MaternGP(
+                length_scales=LENGTH_SCALES,
+                signal_var=SIGNAL_VAR,
+                noise_var=NOISE_VAR,
+                jitter=JITTER,
+            )
+            gp.fit(X_train, y_train)
+            mean, std = gp.predict(X_pred)
+            results.append((mean.copy(), std.copy()))
+
+        for i in range(1, len(results)):
+            mean_diff = float(np.max(np.abs(results[0][0] - results[i][0])))
+            std_diff = float(np.max(np.abs(results[0][1] - results[i][1])))
+            print(f"\n  Trial 0 vs {i}: mean_diff={mean_diff:.2e}, std_diff={std_diff:.2e}")
+            assert mean_diff == 0.0, f"Mean not bit-identical: diff={mean_diff}"
+            assert std_diff == 0.0, f"Std not bit-identical: diff={std_diff}"
+
+
+class TestNumpyLatency:
+    """Verify NumPy engine meets performance contract."""
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("n_train", [30, 80, 150])
+    @pytest.mark.parametrize("grid_name", ["11x5", "16x16"])
+    def test_fit_latency(self, n_train, grid_name):
+        """fit() must complete within budget."""
+        X_train, y_train = _make_training_data(n_train)
+
+        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+
+        timings = []
+        for _ in range(10):
+            gp.invalidate()
+            t0 = time.perf_counter()
+            gp.fit(X_train, y_train)
+            timings.append((time.perf_counter() - t0) * 1000)
+
+        median_ms = float(np.median(timings))
+        print(f"\n  Fit latency [n={n_train}]: median={median_ms:.2f}ms, "
+              f"all={[f'{t:.2f}' for t in timings]}")
+
+        # Contract: < 10ms for ≤ 150 points
+        assert median_ms < 10.0, f"Fit too slow: {median_ms:.2f}ms (budget: 10ms)"
+
+    @pytest.mark.parametrize("n_train", [30, 80, 150])
+    @pytest.mark.parametrize("grid_name", ["11x5", "16x16"])
+    def test_predict_latency(self, n_train, grid_name):
+        """predict() must complete within budget."""
+        X_train, y_train = _make_training_data(n_train)
+        rpm_norm, map_norm = GRID_SHAPES[grid_name]
+        X_pred = _make_pred_grid(rpm_norm, map_norm)
+
+        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp.fit(X_train, y_train)
+
+        timings = []
+        for _ in range(20):
+            t0 = time.perf_counter()
+            gp.predict(X_pred)
+            timings.append((time.perf_counter() - t0) * 1000)
+
+        median_ms = float(np.median(timings))
+        n_pred = X_pred.shape[0]
+        print(f"\n  Predict latency [{grid_name}, n_train={n_train}, n_pred={n_pred}]: "
+              f"median={median_ms:.2f}ms")
+
+        # Contract: < 2ms for cached prediction
+        assert median_ms < 2.0, f"Predict too slow: {median_ms:.2f}ms (budget: 2ms)"
+
+
+class TestEdgeCases:
+    """Edge cases the engine must handle."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_single_observation(self):
+        """GP with n=1 should not crash."""
+        X = np.array([[0.5, 0.5]])
+        y = np.array([90.0])
+
+        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp.fit(X, y)
+
+        X_pred = np.array([[0.5, 0.5], [0.0, 0.0], [1.0, 1.0]])
+        mean, std = gp.predict(X_pred)
+
+        assert mean.shape == (3,)
+        assert std.shape == (3,)
+        assert np.all(std >= 0)
+        # Near the training point, mean should be close to 90
+        assert abs(mean[0] - 90.0) < 1.0
+
+    def test_constant_y(self):
+        """Constant y should not crash (std of y = 0 edge case)."""
+        X = np.random.RandomState(42).rand(20, 2)
+        y = np.full(20, 85.0)
+
+        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp.fit(X, y)
+
+        X_pred = np.array([[0.5, 0.5]])
+        mean, std = gp.predict(X_pred)
+
+        assert abs(mean[0] - 85.0) < 0.5
+        assert std[0] >= 0
+
+    def test_empty_training_set(self):
+        """Empty fit → predict raises."""
+        gp = MaternGP()
+        gp.fit(np.zeros((0, 2)), np.zeros(0))
+        assert not gp.is_fitted
+
+        with pytest.raises(RuntimeError, match="before fit"):
+            gp.predict(np.array([[0.5, 0.5]]))
+
+    def test_predict_without_fit_raises(self):
+        """predict() before fit() raises RuntimeError."""
+        gp = MaternGP()
+        with pytest.raises(RuntimeError, match="before fit"):
+            gp.predict(np.array([[0.5, 0.5]]))
+
+    def test_invalidate_clears_cache(self):
+        """invalidate() clears the fit cache."""
+        X, y = _make_training_data(20)
+        gp = MaternGP()
+        gp.fit(X, y)
+        assert gp.is_fitted
+
+        gp.invalidate()
+        assert not gp.is_fitted
+
+    def test_hyperparameter_reporting(self):
+        """get_hyperparameters returns correct values."""
+        gp = MaternGP(
+            length_scales=np.array([0.4, 0.25]),
+            signal_var=1.5,
+            noise_var=0.2,
+            jitter=1e-6,
+        )
+        hp = gp.get_hyperparameters()
+        assert hp["length_scales"] == [0.4, 0.25]
+        assert hp["signal_var"] == 1.5
+        assert hp["noise_var"] == 0.2
+        assert hp["jitter"] == 1e-6
+
+    def test_large_grid_prediction(self):
+        """Predict on 32×32 = 1024 grid cells (exceeds 256)."""
+        X_train, y_train = _make_training_data(50)
+        rpm_norm = np.linspace(0, 1, 32)
+        map_norm = np.linspace(0, 1, 32)
+        X_pred = _make_pred_grid(rpm_norm, map_norm)
+
+        gp = MaternGP(length_scales=LENGTH_SCALES, signal_var=SIGNAL_VAR, noise_var=NOISE_VAR)
+        gp.fit(X_train, y_train)
+        mean, std = gp.predict(X_pred)
+
+        assert mean.shape == (1024,)
+        assert std.shape == (1024,)
+        assert np.all(np.isfinite(mean))
+        assert np.all(std >= 0)

--- a/tests/test_gp_holdout_harness.py
+++ b/tests/test_gp_holdout_harness.py
@@ -43,11 +43,17 @@ import pytest
 # ---------------------------------------------------------------------------
 GRID_SHAPES: Dict[str, Tuple[np.ndarray, np.ndarray]] = {
     "10x9_test": (
-        np.array([1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500], dtype=np.float64),
+        np.array(
+            [1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500],
+            dtype=np.float64,
+        ),
         np.array([30, 40, 50, 60, 70, 80, 90, 100, 105], dtype=np.float64),
     ),
     "11x5_production": (
-        np.array([1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500, 6000, 6500], dtype=np.float64),
+        np.array(
+            [1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500, 6000, 6500],
+            dtype=np.float64,
+        ),
         np.array([35, 50, 65, 80, 95], dtype=np.float64),
     ),
     "16x16_budget": (
@@ -60,7 +66,9 @@ GRID_SHAPES: Dict[str, Tuple[np.ndarray, np.ndarray]] = {
 # ---------------------------------------------------------------------------
 # Synthetic data generators (deterministic, seeded)
 # ---------------------------------------------------------------------------
-def _make_ve_surface(rpm_bins: np.ndarray, map_bins: np.ndarray, seed: int = 42) -> np.ndarray:
+def _make_ve_surface(
+    rpm_bins: np.ndarray, map_bins: np.ndarray, seed: int = 42
+) -> np.ndarray:
     """
     Generate a physically plausible VE surface for testing.
 
@@ -78,9 +86,9 @@ def _make_ve_surface(rpm_bins: np.ndarray, map_bins: np.ndarray, seed: int = 42)
 
     for r in range(n_rpm):
         for m in range(n_map):
-            base = 75.0 + 25.0 * map_norm[m]                  # 75% at min MAP → 100% at max
-            rpm_shape = 5.0 * np.sin(np.pi * rpm_norm[r])     # ±5% bell over RPM
-            interaction = 3.0 * rpm_norm[r] * map_norm[m]      # slight RPM×MAP coupling
+            base = 75.0 + 25.0 * map_norm[m]  # 75% at min MAP → 100% at max
+            rpm_shape = 5.0 * np.sin(np.pi * rpm_norm[r])  # ±5% bell over RPM
+            interaction = 3.0 * rpm_norm[r] * map_norm[m]  # slight RPM×MAP coupling
             table[r, m] = base + rpm_shape + interaction
 
     # Small noise so GP has something to learn beyond smooth trend
@@ -115,13 +123,15 @@ def _generate_observations(
         true_ve = ve_surface[r_idx, m_idx]
         measured_ve = true_ve + rng.randn() * noise_std
 
-        observations.append({
-            "rpm": float(rpm_bins[r_idx] + rpm_jitter),
-            "map_kpa": float(map_bins[m_idx] + map_jitter),
-            "ve": float(measured_ve),
-            "grid_r": r_idx,
-            "grid_m": m_idx,
-        })
+        observations.append(
+            {
+                "rpm": float(rpm_bins[r_idx] + rpm_jitter),
+                "map_kpa": float(map_bins[m_idx] + map_jitter),
+                "ve": float(measured_ve),
+                "grid_r": r_idx,
+                "grid_m": m_idx,
+            }
+        )
 
     return observations
 
@@ -188,23 +198,34 @@ class HarnessMetrics:
             f"  mode: {self.mode}",
         ]
         if self.mae is not None:
-            parts.append(f"  MAE: {self.mae:.4f}  RMSE: {self.rmse:.4f}  MaxErr: {self.max_error:.4f}")
+            parts.append(
+                f"  MAE: {self.mae:.4f}  RMSE: {self.rmse:.4f}  MaxErr: {self.max_error:.4f}"
+            )
         if self.mean_uncertainty_holdout is not None:
             parts.append(f"  mean_unc(holdout): {self.mean_uncertainty_holdout:.4f}")
         if self.mean_uncertainty_full is not None:
-            conf_str = f"{self.mean_confidence_full:.1f}" if self.mean_confidence_full is not None else "—"
-            parts.append(f"  mean_unc(full): {self.mean_uncertainty_full:.4f}  mean_conf(full): {conf_str}")
+            conf_str = (
+                f"{self.mean_confidence_full:.1f}"
+                if self.mean_confidence_full is not None
+                else "—"
+            )
+            parts.append(
+                f"  mean_unc(full): {self.mean_uncertainty_full:.4f}  mean_conf(full): {conf_str}"
+            )
         if self.predict_full_map_ms is not None:
-            parts.append(f"  latency: predict_full_map={self.predict_full_map_ms:.1f}ms")
+            parts.append(
+                f"  latency: predict_full_map={self.predict_full_map_ms:.1f}ms"
+            )
         if self.refit_ms is not None:
             parts.append(f"  latency: refit={self.refit_ms:.1f}ms")
-        parts.append(f"  obs in model: {self.total_obs_in_model} (template: {self.template_obs_in_model})")
+        parts.append(
+            f"  obs in model: {self.total_obs_in_model} (template: {self.template_obs_in_model})"
+        )
         return "\n".join(parts)
 
 
 # Accumulate metrics across all tests for final report
 _all_metrics: List[HarnessMetrics] = []
-
 
 # ---------------------------------------------------------------------------
 # Backend abstraction — switch between sklearn and numpy
@@ -212,18 +233,29 @@ _all_metrics: List[HarnessMetrics] = []
 BACKEND = "sklearn"
 
 
-def _create_surrogate(rpm_bins: np.ndarray, map_bins: np.ndarray, engine_family: str = "m8_114"):
+def _create_surrogate(
+    rpm_bins: np.ndarray, map_bins: np.ndarray, engine_family: str = "m8_114"
+):
     """Create a VESurrogate using the current backend."""
     from dynoai_v3.gp_surrogate import VESurrogate
+
     return VESurrogate(rpm_bins, map_bins, engine_family, backend=BACKEND)
 
 
-def _add_observation(surrogate, rpm: float, map_kpa: float, ve: float, pull_number: int = 1):
+def _add_observation(
+    surrogate, rpm: float, map_kpa: float, ve: float, pull_number: int = 1
+):
     """Add a single observation."""
     from dynoai_v3.gp_surrogate import Observation
-    surrogate.add_observation(Observation(
-        rpm=rpm, map_kpa=map_kpa, ve_delta=ve, pull_number=pull_number,
-    ))
+
+    surrogate.add_observation(
+        Observation(
+            rpm=rpm,
+            map_kpa=map_kpa,
+            ve_delta=ve,
+            pull_number=pull_number,
+        )
+    )
 
 
 def _predict_at(surrogate, rpm: float, map_kpa: float):
@@ -327,7 +359,8 @@ class TestTemplateOnly:
 
         # Core contract: template-only should return exact seed values
         np.testing.assert_array_equal(
-            pred.ve_map, ve_surface,
+            pred.ve_map,
+            ve_surface,
             err_msg="Template-only prediction must return exact seed table",
         )
 
@@ -427,7 +460,9 @@ class TestRealDataOnly:
 
         # More observations needed without template prior
         n_obs = min(120, len(rpm_bins) * len(map_bins) * 3)
-        all_obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=77)
+        all_obs = _generate_observations(
+            ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=77
+        )
         train, holdout = _holdout_split(all_obs)
 
         s = _create_surrogate(rpm_bins, map_bins)
@@ -478,7 +513,9 @@ class TestRealDataOnly:
         _all_metrics.append(metrics)
         print(f"\n{metrics.summary()}")
 
-        assert mae < 10.0, f"MAE too high without template: {mae:.4f} (must be < 10.0 VE%)"
+        assert mae < 10.0, (
+            f"MAE too high without template: {mae:.4f} (must be < 10.0 VE%)"
+        )
         assert pred.ve_map.shape == (len(rpm_bins), len(map_bins))
 
 
@@ -498,7 +535,9 @@ class TestLatencyBudget:
 
         # Add some real data to trigger GP fit
         n_obs = 30
-        obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=55)
+        obs = _generate_observations(
+            ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=55
+        )
         for o in obs:
             _add_observation(s, o["rpm"], o["map_kpa"], o["ve"])
 
@@ -535,7 +574,9 @@ class TestLatencyBudget:
         print(f"  all timings: {[f'{t:.1f}ms' for t in timings]}")
 
         # Budget: 500ms for prediction (generous; target is <100ms)
-        assert median_ms < 500, f"Prediction too slow: {median_ms:.1f}ms (budget: 500ms)"
+        assert median_ms < 500, (
+            f"Prediction too slow: {median_ms:.1f}ms (budget: 500ms)"
+        )
 
 
 class TestObservationPruning:
@@ -575,6 +616,7 @@ class TestObservationPruning:
         # Total should be bounded
         # (template_count + _MAX_PULL_OBS_STORED)
         from dynoai_v3.gp_surrogate import _MAX_PULL_OBS_STORED
+
         max_expected = template_count + _MAX_PULL_OBS_STORED
         assert len(s.observations) <= max_expected, (
             f"Observations not pruned: {len(s.observations)} > {max_expected}"
@@ -615,6 +657,7 @@ class TestMissingAlphaFallback:
 
         # Manually force the fallback state
         from dynoai_v3.gp_surrogate import Observation
+
         for rpm in [2500, 3000, 3500]:
             s.add_observation(Observation(rpm=rpm, map_kpa=100, ve_delta=85.0))
 
@@ -630,7 +673,9 @@ class TestMissingAlphaFallback:
 
         # Should fall back to high-uncertainty prior
         assert pred.ve_map.shape == (len(rpm_bins), len(map_bins))
-        assert np.all(pred.uncertainty_map >= 5.0), "Fallback should have high uncertainty"
+        assert np.all(pred.uncertainty_map >= 5.0), (
+            "Fallback should have high uncertainty"
+        )
 
         metrics = HarnessMetrics(
             scenario="alpha_fallback",
@@ -664,7 +709,9 @@ class TestDeterminism:
             s = _create_surrogate(rpm_bins, map_bins)
             s.seed_from_template(ve_surface, rpm_bins, map_bins)
 
-            obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=30, seed=42)
+            obs = _generate_observations(
+                ve_surface, rpm_bins, map_bins, n_obs=30, seed=42
+            )
             for o in obs:
                 _add_observation(s, o["rpm"], o["map_kpa"], o["ve"])
 
@@ -704,7 +751,11 @@ class TestCapSizeTraining:
         # Generate observations near the cap
         n_obs = min(_MAX_OBS_FOR_REFIT, 150)
         all_obs = _generate_observations(
-            ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=303,
+            ve_surface,
+            rpm_bins,
+            map_bins,
+            n_obs=n_obs,
+            seed=303,
         )
         train, holdout = _holdout_split(all_obs, holdout_fraction=0.2)
 
@@ -778,6 +829,7 @@ class TestNumpyBackendAB:
 
     def _create_numpy_surrogate(self, rpm_bins, map_bins, engine_family="m8_114"):
         from dynoai_v3.gp_surrogate import VESurrogate
+
         return VESurrogate(rpm_bins, map_bins, engine_family, backend="numpy")
 
     @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
@@ -840,7 +892,9 @@ class TestNumpyBackendAB:
         ve_surface = _make_ve_surface(rpm_bins, map_bins)
 
         n_obs = min(120, len(rpm_bins) * len(map_bins) * 3)
-        all_obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=77)
+        all_obs = _generate_observations(
+            ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=77
+        )
         train, holdout = _holdout_split(all_obs)
 
         s = self._create_numpy_surrogate(rpm_bins, map_bins)
@@ -899,7 +953,9 @@ class TestNumpyBackendAB:
         for _ in range(3):
             s = self._create_numpy_surrogate(rpm_bins, map_bins)
             s.seed_from_template(ve_surface, rpm_bins, map_bins)
-            obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=30, seed=42)
+            obs = _generate_observations(
+                ve_surface, rpm_bins, map_bins, n_obs=30, seed=42
+            )
             for o in obs:
                 _add_observation(s, o["rpm"], o["map_kpa"], o["ve"])
             pred = _predict_full_map(s)
@@ -935,7 +991,9 @@ class TestNumpyBackendAB:
             timings.append((time.perf_counter() - t0) * 1000)
         cached_ms = float(np.median(timings))
 
-        print(f"\n  Numpy latency [{grid_name}]: first={first_ms:.1f}ms, cached={cached_ms:.2f}ms")
+        print(
+            f"\n  Numpy latency [{grid_name}]: first={first_ms:.1f}ms, cached={cached_ms:.2f}ms"
+        )
 
         # Numpy contract: first fit < 10ms, cached < 2ms
         assert first_ms < 50, f"First fit too slow: {first_ms:.1f}ms"
@@ -955,7 +1013,9 @@ class TestNumpyBackendAB:
         ve_surface = _make_ve_surface(rpm_bins, map_bins)
 
         n_obs = min(60, len(rpm_bins) * len(map_bins) * 2)
-        obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=888)
+        obs = _generate_observations(
+            ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=888
+        )
 
         # sklearn
         s_sk = VESurrogate(rpm_bins, map_bins, "m8_114", backend="sklearn")
@@ -973,7 +1033,9 @@ class TestNumpyBackendAB:
         mae = float(np.mean(np.abs(diff)))
         max_diff = float(np.max(np.abs(diff)))
 
-        print(f"\n  sklearn vs numpy [{grid_name}]: MAE={mae:.4f}, max_diff={max_diff:.4f}")
+        print(
+            f"\n  sklearn vs numpy [{grid_name}]: MAE={mae:.4f}, max_diff={max_diff:.4f}"
+        )
 
         # Loose: sklearn optimizes hyperparams, numpy freezes them
         assert mae < 3.0, f"Backend disagreement too large: MAE={mae:.4f}"
@@ -985,6 +1047,7 @@ class TestNumpyBackendAB:
 @pytest.fixture(scope="session", autouse=True)
 def _print_final_report(request):
     """Print full metrics report after all tests complete."""
+
     def _report():
         if not _all_metrics:
             return
@@ -1006,7 +1069,9 @@ def _print_final_report(request):
             print(f"{'Scenario':<25} {'Grid':<15} {'MAE':>8} {'RMSE':>8} {'MaxErr':>8}")
             print("-" * 60)
             for m in accuracy_runs:
-                print(f"{m.scenario:<25} {m.grid_shape:<15} {m.mae:>8.4f} {m.rmse:>8.4f} {m.max_error:>8.4f}")
+                print(
+                    f"{m.scenario:<25} {m.grid_shape:<15} {m.mae:>8.4f} {m.rmse:>8.4f} {m.max_error:>8.4f}"
+                )
 
         # Latency summary
         latency_runs = [m for m in _all_metrics if m.predict_full_map_ms is not None]
@@ -1017,7 +1082,11 @@ def _print_final_report(request):
             print("-" * 60)
             for m in latency_runs:
                 refit = f"{m.refit_ms:.1f}" if m.refit_ms is not None else "—"
-                pred = f"{m.predict_full_map_ms:.1f}" if m.predict_full_map_ms is not None else "—"
+                pred = (
+                    f"{m.predict_full_map_ms:.1f}"
+                    if m.predict_full_map_ms is not None
+                    else "—"
+                )
                 print(f"{m.scenario:<25} {m.grid_shape:<15} {pred:>12} {refit:>12}")
 
         print("\n" + "=" * 78)

--- a/tests/test_gp_holdout_harness.py
+++ b/tests/test_gp_holdout_harness.py
@@ -1,0 +1,1025 @@
+"""
+DynoAI GP Backend — Holdout Validation Harness
+================================================
+
+Objective: Establish a measurable baseline for the current sklearn GP backend
+before migrating to a pure NumPy engine. Records per-scenario metrics so the
+NumPy engine can be validated against the same contract.
+
+Scenarios exercised:
+    1. Unfitted model → high-uncertainty prior (edge case)
+    2. Template-only seeding → exact seed table passthrough (edge case)
+    3. Template + real data → GP blends both sources (normal fit)
+    4. Real data only (no template) → GP fits from scratch (normal fit)
+    5. Holdout prediction accuracy across multiple grid shapes
+    6. Latency measurement for predict_full_map
+    7. Observation pruning under _MAX_OBS_FOR_REFIT cap
+
+Grid shapes tested:
+    - 10×9  (test fixture default, matches test_v3_modules.py)
+    - 11×5  (production constants from dynoai/constants.py)
+    - 16×16 (documented performance budget target)
+
+Usage:
+    pytest tests/test_gp_holdout_harness.py -v
+    pytest tests/test_gp_holdout_harness.py -v -s  # with metric printout
+
+Author: Thunderhorse Tuning / DynoAI
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Grid shape definitions — exercise multiple runtime configurations
+# ---------------------------------------------------------------------------
+GRID_SHAPES: Dict[str, Tuple[np.ndarray, np.ndarray]] = {
+    "10x9_test": (
+        np.array([1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500], dtype=np.float64),
+        np.array([30, 40, 50, 60, 70, 80, 90, 100, 105], dtype=np.float64),
+    ),
+    "11x5_production": (
+        np.array([1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500, 6000, 6500], dtype=np.float64),
+        np.array([35, 50, 65, 80, 95], dtype=np.float64),
+    ),
+    "16x16_budget": (
+        np.linspace(1000, 6500, 16).astype(np.float64),
+        np.linspace(25, 105, 16).astype(np.float64),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data generators (deterministic, seeded)
+# ---------------------------------------------------------------------------
+def _make_ve_surface(rpm_bins: np.ndarray, map_bins: np.ndarray, seed: int = 42) -> np.ndarray:
+    """
+    Generate a physically plausible VE surface for testing.
+
+    Shape matches a V-twin: VE rises with MAP, peaks in mid-RPM, falls
+    at high RPM. Values in absolute VE % (70-110).
+    """
+    rng = np.random.RandomState(seed)
+    n_rpm, n_map = len(rpm_bins), len(map_bins)
+    table = np.zeros((n_rpm, n_map))
+
+    rpm_range = float(rpm_bins.max() - rpm_bins.min()) or 1.0
+    map_range = float(map_bins.max() - map_bins.min()) or 1.0
+    rpm_norm = (rpm_bins - rpm_bins.min()) / rpm_range
+    map_norm = (map_bins - map_bins.min()) / map_range
+
+    for r in range(n_rpm):
+        for m in range(n_map):
+            base = 75.0 + 25.0 * map_norm[m]                  # 75% at min MAP → 100% at max
+            rpm_shape = 5.0 * np.sin(np.pi * rpm_norm[r])     # ±5% bell over RPM
+            interaction = 3.0 * rpm_norm[r] * map_norm[m]      # slight RPM×MAP coupling
+            table[r, m] = base + rpm_shape + interaction
+
+    # Small noise so GP has something to learn beyond smooth trend
+    table += rng.randn(n_rpm, n_map) * 0.5
+    return table
+
+
+def _generate_observations(
+    ve_surface: np.ndarray,
+    rpm_bins: np.ndarray,
+    map_bins: np.ndarray,
+    n_obs: int,
+    noise_std: float = 0.5,
+    seed: int = 123,
+) -> List[dict]:
+    """
+    Sample observations from a known VE surface with measurement noise.
+
+    Returns list of dicts with keys: rpm, map_kpa, ve, grid_r, grid_m.
+    grid_r/grid_m are the true grid indices (for holdout bookkeeping).
+    """
+    rng = np.random.RandomState(seed)
+    observations = []
+    n_rpm, n_map = len(rpm_bins), len(map_bins)
+
+    for _ in range(n_obs):
+        r_idx = rng.randint(0, n_rpm)
+        m_idx = rng.randint(0, n_map)
+        # Jitter around bin center (realistic: samples don't land exactly on bin)
+        rpm_jitter = rng.uniform(-100, 100)
+        map_jitter = rng.uniform(-3, 3)
+        true_ve = ve_surface[r_idx, m_idx]
+        measured_ve = true_ve + rng.randn() * noise_std
+
+        observations.append({
+            "rpm": float(rpm_bins[r_idx] + rpm_jitter),
+            "map_kpa": float(map_bins[m_idx] + map_jitter),
+            "ve": float(measured_ve),
+            "grid_r": r_idx,
+            "grid_m": m_idx,
+        })
+
+    return observations
+
+
+def _holdout_split(
+    observations: List[dict],
+    holdout_fraction: float = 0.3,
+    seed: int = 99,
+) -> Tuple[List[dict], List[dict]]:
+    """Split observations into train and holdout sets."""
+    rng = np.random.RandomState(seed)
+    indices = rng.permutation(len(observations))
+    n_holdout = max(1, int(len(observations) * holdout_fraction))
+    holdout_idx = set(indices[:n_holdout].tolist())
+
+    train = [o for i, o in enumerate(observations) if i not in holdout_idx]
+    holdout = [o for i, o in enumerate(observations) if i in holdout_idx]
+    return train, holdout
+
+
+# ---------------------------------------------------------------------------
+# Metrics recording
+# ---------------------------------------------------------------------------
+@dataclass
+class HarnessMetrics:
+    """Metrics from a single harness scenario run."""
+
+    scenario: str
+    backend: str
+    grid_shape: str
+    n_rpm: int
+    n_map: int
+    n_train: int
+    n_holdout: int
+    n_template: int
+
+    # Prediction quality (holdout cells)
+    mae: Optional[float] = None
+    rmse: Optional[float] = None
+    max_error: Optional[float] = None
+    mean_uncertainty_holdout: Optional[float] = None
+
+    # Full map stats
+    mean_uncertainty_full: Optional[float] = None
+    min_confidence_full: Optional[float] = None
+    mean_confidence_full: Optional[float] = None
+
+    # Latency
+    predict_full_map_ms: Optional[float] = None
+    refit_ms: Optional[float] = None
+
+    # Edge case mode
+    mode: str = "normal_fit"  # unfitted, template_only, normal_fit, fallback
+
+    # Observation management
+    total_obs_in_model: int = 0
+    template_obs_in_model: int = 0
+
+    def summary(self) -> str:
+        parts = [
+            f"[{self.backend}] {self.scenario} ({self.grid_shape})",
+            f"  grid: {self.n_rpm}×{self.n_map} = {self.n_rpm * self.n_map} cells",
+            f"  train: {self.n_train}, holdout: {self.n_holdout}, template: {self.n_template}",
+            f"  mode: {self.mode}",
+        ]
+        if self.mae is not None:
+            parts.append(f"  MAE: {self.mae:.4f}  RMSE: {self.rmse:.4f}  MaxErr: {self.max_error:.4f}")
+        if self.mean_uncertainty_holdout is not None:
+            parts.append(f"  mean_unc(holdout): {self.mean_uncertainty_holdout:.4f}")
+        if self.mean_uncertainty_full is not None:
+            conf_str = f"{self.mean_confidence_full:.1f}" if self.mean_confidence_full is not None else "—"
+            parts.append(f"  mean_unc(full): {self.mean_uncertainty_full:.4f}  mean_conf(full): {conf_str}")
+        if self.predict_full_map_ms is not None:
+            parts.append(f"  latency: predict_full_map={self.predict_full_map_ms:.1f}ms")
+        if self.refit_ms is not None:
+            parts.append(f"  latency: refit={self.refit_ms:.1f}ms")
+        parts.append(f"  obs in model: {self.total_obs_in_model} (template: {self.template_obs_in_model})")
+        return "\n".join(parts)
+
+
+# Accumulate metrics across all tests for final report
+_all_metrics: List[HarnessMetrics] = []
+
+
+# ---------------------------------------------------------------------------
+# Backend abstraction — switch between sklearn and numpy
+# ---------------------------------------------------------------------------
+BACKEND = "sklearn"
+
+
+def _create_surrogate(rpm_bins: np.ndarray, map_bins: np.ndarray, engine_family: str = "m8_114"):
+    """Create a VESurrogate using the current backend."""
+    from dynoai_v3.gp_surrogate import VESurrogate
+    return VESurrogate(rpm_bins, map_bins, engine_family, backend=BACKEND)
+
+
+def _add_observation(surrogate, rpm: float, map_kpa: float, ve: float, pull_number: int = 1):
+    """Add a single observation."""
+    from dynoai_v3.gp_surrogate import Observation
+    surrogate.add_observation(Observation(
+        rpm=rpm, map_kpa=map_kpa, ve_delta=ve, pull_number=pull_number,
+    ))
+
+
+def _predict_at(surrogate, rpm: float, map_kpa: float):
+    """Predict at a single point. Returns (mean, uncertainty)."""
+    pred = surrogate.predict(rpm, map_kpa)
+    return pred.ve_delta, pred.uncertainty
+
+
+def _predict_full_map(surrogate):
+    """Predict full map. Returns FullMapPrediction."""
+    return surrogate.predict_full_map()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(params=list(GRID_SHAPES.keys()))
+def grid_shape(request):
+    """Parametrize over grid shapes."""
+    name = request.param
+    rpm_bins, map_bins = GRID_SHAPES[name]
+    return name, rpm_bins, map_bins
+
+
+# ---------------------------------------------------------------------------
+# Test scenarios
+# ---------------------------------------------------------------------------
+class TestUnfittedModel:
+    """Scenario 1: No data, no template. Model should return high-uncertainty prior."""
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_unfitted_returns_high_uncertainty(self, grid_name):
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        s = _create_surrogate(rpm_bins, map_bins)
+
+        metrics = HarnessMetrics(
+            scenario="unfitted_prior",
+            backend=BACKEND,
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=0,
+            n_holdout=0,
+            n_template=0,
+            mode="unfitted",
+        )
+
+        # Single point prediction
+        mean, unc = _predict_at(s, 3500, 90)
+        assert unc >= 5.0, f"Unfitted model uncertainty too low: {unc}"
+
+        # Full map prediction
+        t0 = time.perf_counter()
+        pred = _predict_full_map(s)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        assert pred.ve_map.shape == (len(rpm_bins), len(map_bins))
+        assert pred.uncertainty_map.shape == pred.ve_map.shape
+        assert np.all(pred.uncertainty_map >= 5.0)
+
+        metrics.mean_uncertainty_full = float(np.mean(pred.uncertainty_map))
+        metrics.mean_confidence_full = float(np.mean(pred.confidence_map))
+        metrics.min_confidence_full = float(np.min(pred.confidence_map))
+        metrics.predict_full_map_ms = elapsed_ms
+        metrics.total_obs_in_model = s.observation_count
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+
+class TestTemplateOnly:
+    """Scenario 2: Template seeded, no real pulls. Should passthrough exact seed table."""
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_template_passthrough(self, grid_name):
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        s = _create_surrogate(rpm_bins, map_bins)
+        s.seed_from_template(ve_surface, rpm_bins, map_bins)
+
+        metrics = HarnessMetrics(
+            scenario="template_only",
+            backend=BACKEND,
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=0,
+            n_holdout=0,
+            n_template=len(rpm_bins) * len(map_bins),
+            mode="template_only",
+        )
+
+        t0 = time.perf_counter()
+        pred = _predict_full_map(s)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        # Core contract: template-only should return exact seed values
+        np.testing.assert_array_equal(
+            pred.ve_map, ve_surface,
+            err_msg="Template-only prediction must return exact seed table",
+        )
+
+        metrics.predict_full_map_ms = elapsed_ms
+        metrics.mean_uncertainty_full = float(np.mean(pred.uncertainty_map))
+        metrics.mean_confidence_full = float(np.mean(pred.confidence_map))
+        metrics.min_confidence_full = float(np.min(pred.confidence_map))
+        metrics.total_obs_in_model = s.observation_count
+        metrics.template_obs_in_model = s.template_observation_count
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+
+class TestTemplateWithRealData:
+    """Scenario 3: Template + real dyno observations. GP should blend both."""
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_holdout_accuracy(self, grid_name):
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        # Generate observations from the known surface
+        n_obs = min(80, len(rpm_bins) * len(map_bins) * 2)
+        all_obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs)
+        train, holdout = _holdout_split(all_obs)
+
+        # Build surrogate: template + training data
+        s = _create_surrogate(rpm_bins, map_bins)
+        s.seed_from_template(ve_surface, rpm_bins, map_bins)
+
+        for obs in train:
+            _add_observation(s, obs["rpm"], obs["map_kpa"], obs["ve"], pull_number=1)
+
+        # Predict full map
+        t0 = time.perf_counter()
+        pred = _predict_full_map(s)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        # Evaluate on holdout: compare predicted VE at each holdout point's grid cell
+        errors = []
+        holdout_uncertainties = []
+        for obs in holdout:
+            r, m = obs["grid_r"], obs["grid_m"]
+            predicted = pred.ve_map[r, m]
+            actual = ve_surface[r, m]  # Compare to true surface, not noisy measurement
+            errors.append(predicted - actual)
+            holdout_uncertainties.append(pred.uncertainty_map[r, m])
+
+        errors = np.array(errors)
+        mae = float(np.mean(np.abs(errors)))
+        rmse = float(np.sqrt(np.mean(errors**2)))
+        max_err = float(np.max(np.abs(errors)))
+
+        metrics = HarnessMetrics(
+            scenario="template_plus_real",
+            backend=BACKEND,
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=len(train),
+            n_holdout=len(holdout),
+            n_template=len(rpm_bins) * len(map_bins),
+            mode="normal_fit",
+            mae=mae,
+            rmse=rmse,
+            max_error=max_err,
+            mean_uncertainty_holdout=float(np.mean(holdout_uncertainties)),
+            mean_uncertainty_full=float(np.mean(pred.uncertainty_map)),
+            mean_confidence_full=float(np.mean(pred.confidence_map)),
+            min_confidence_full=float(np.min(pred.confidence_map)),
+            predict_full_map_ms=elapsed_ms,
+            refit_ms=s._last_fit_time_ms,
+            total_obs_in_model=s.observation_count,
+            template_obs_in_model=s.template_observation_count,
+        )
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+        # Baseline assertions — these define the contract the numpy engine must meet
+        assert mae < 5.0, f"MAE too high: {mae:.4f} (must be < 5.0 VE%)"
+        assert pred.ve_map.shape == (len(rpm_bins), len(map_bins))
+
+
+class TestRealDataOnly:
+    """Scenario 4: No template, only real observations. GP fits from scratch."""
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_holdout_accuracy_no_template(self, grid_name):
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        # More observations needed without template prior
+        n_obs = min(120, len(rpm_bins) * len(map_bins) * 3)
+        all_obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=77)
+        train, holdout = _holdout_split(all_obs)
+
+        s = _create_surrogate(rpm_bins, map_bins)
+        for obs in train:
+            _add_observation(s, obs["rpm"], obs["map_kpa"], obs["ve"], pull_number=1)
+
+        t0 = time.perf_counter()
+        pred = _predict_full_map(s)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        errors = []
+        holdout_uncertainties = []
+        for obs in holdout:
+            r, m = obs["grid_r"], obs["grid_m"]
+            predicted = pred.ve_map[r, m]
+            actual = ve_surface[r, m]
+            errors.append(predicted - actual)
+            holdout_uncertainties.append(pred.uncertainty_map[r, m])
+
+        errors = np.array(errors)
+        mae = float(np.mean(np.abs(errors)))
+        rmse = float(np.sqrt(np.mean(errors**2)))
+        max_err = float(np.max(np.abs(errors)))
+
+        metrics = HarnessMetrics(
+            scenario="real_data_only",
+            backend=BACKEND,
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=len(train),
+            n_holdout=len(holdout),
+            n_template=0,
+            mode="normal_fit",
+            mae=mae,
+            rmse=rmse,
+            max_error=max_err,
+            mean_uncertainty_holdout=float(np.mean(holdout_uncertainties)),
+            mean_uncertainty_full=float(np.mean(pred.uncertainty_map)),
+            mean_confidence_full=float(np.mean(pred.confidence_map)),
+            min_confidence_full=float(np.min(pred.confidence_map)),
+            predict_full_map_ms=elapsed_ms,
+            refit_ms=s._last_fit_time_ms,
+            total_obs_in_model=s.observation_count,
+            template_obs_in_model=0,
+        )
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+        assert mae < 10.0, f"MAE too high without template: {mae:.4f} (must be < 10.0 VE%)"
+        assert pred.ve_map.shape == (len(rpm_bins), len(map_bins))
+
+
+class TestLatencyBudget:
+    """Scenario 6: Verify predict_full_map stays within latency budget."""
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_predict_latency(self, grid_name):
+        """Full map prediction must complete within 500ms for any grid shape."""
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        s = _create_surrogate(rpm_bins, map_bins)
+        s.seed_from_template(ve_surface, rpm_bins, map_bins)
+
+        # Add some real data to trigger GP fit
+        n_obs = 30
+        obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=55)
+        for o in obs:
+            _add_observation(s, o["rpm"], o["map_kpa"], o["ve"])
+
+        # Warm-up fit (don't count first fit in latency)
+        _ = _predict_full_map(s)
+
+        # Timed prediction (model already fitted, cache should help)
+        timings = []
+        for _ in range(5):
+            t0 = time.perf_counter()
+            pred = _predict_full_map(s)
+            elapsed_ms = (time.perf_counter() - t0) * 1000
+            timings.append(elapsed_ms)
+
+        median_ms = float(np.median(timings))
+
+        metrics = HarnessMetrics(
+            scenario="latency_budget",
+            backend=BACKEND,
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=n_obs,
+            n_holdout=0,
+            n_template=len(rpm_bins) * len(map_bins),
+            mode="normal_fit",
+            predict_full_map_ms=median_ms,
+            total_obs_in_model=s.observation_count,
+            template_obs_in_model=s.template_observation_count,
+        )
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+        print(f"  all timings: {[f'{t:.1f}ms' for t in timings]}")
+
+        # Budget: 500ms for prediction (generous; target is <100ms)
+        assert median_ms < 500, f"Prediction too slow: {median_ms:.1f}ms (budget: 500ms)"
+
+
+class TestObservationPruning:
+    """Scenario 7: Verify observation cap and template retention under pruning."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_pruning_retains_templates(self):
+        """When exceeding _MAX_OBS_FOR_REFIT, template observations are preserved."""
+        from dynoai_v3.gp_surrogate import _MAX_OBS_FOR_REFIT
+
+        rpm_bins, map_bins = GRID_SHAPES["10x9_test"]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        s = _create_surrogate(rpm_bins, map_bins)
+        s.seed_from_template(ve_surface, rpm_bins, map_bins)
+        template_count = s.template_observation_count
+
+        # Add enough real observations to exceed the cap
+        n_extra = _MAX_OBS_FOR_REFIT + 50
+        rng = np.random.RandomState(42)
+        for i in range(n_extra):
+            _add_observation(
+                s,
+                rpm=float(rng.choice(rpm_bins)),
+                map_kpa=float(rng.choice(map_bins)),
+                ve=float(rng.randn() * 3 + 85),
+                pull_number=i + 1,
+            )
+
+        # Template observations should still be present
+        n_templates = sum(1 for o in s.observations if o.pull_number == -1)
+        assert n_templates == template_count, (
+            f"Template observations lost: expected {template_count}, got {n_templates}"
+        )
+
+        # Total should be bounded
+        # (template_count + _MAX_PULL_OBS_STORED)
+        from dynoai_v3.gp_surrogate import _MAX_PULL_OBS_STORED
+        max_expected = template_count + _MAX_PULL_OBS_STORED
+        assert len(s.observations) <= max_expected, (
+            f"Observations not pruned: {len(s.observations)} > {max_expected}"
+        )
+
+        metrics = HarnessMetrics(
+            scenario="observation_pruning",
+            backend=BACKEND,
+            grid_shape="10x9_test",
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=n_extra,
+            n_holdout=0,
+            n_template=template_count,
+            mode="normal_fit",
+            total_obs_in_model=len(s.observations),
+            template_obs_in_model=n_templates,
+        )
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+
+class TestMissingAlphaFallback:
+    """Scenario: Exercise the alpha_ guard path in predict_full_map.
+
+    The existing code guards against sklearn leaving the model without
+    alpha_ after fit (observed in sklearn 1.8+). This test verifies the
+    fallback behavior produces safe output.
+    """
+
+    pytestmark = pytest.mark.validation
+
+    def test_fallback_returns_prior(self):
+        """If GP model has no alpha_, prediction falls back to high-uncertainty prior."""
+        rpm_bins, map_bins = GRID_SHAPES["10x9_test"]
+        s = _create_surrogate(rpm_bins, map_bins)
+
+        # Manually force the fallback state
+        from dynoai_v3.gp_surrogate import Observation
+        for rpm in [2500, 3000, 3500]:
+            s.add_observation(Observation(rpm=rpm, map_kpa=100, ve_delta=85.0))
+
+        # Trigger fit
+        s._refit()
+        assert s.is_fitted
+
+        # Simulate sklearn bug: remove alpha_ attribute
+        if hasattr(s._gp_model, "alpha_"):
+            delattr(s._gp_model, "alpha_")
+
+        pred = _predict_full_map(s)
+
+        # Should fall back to high-uncertainty prior
+        assert pred.ve_map.shape == (len(rpm_bins), len(map_bins))
+        assert np.all(pred.uncertainty_map >= 5.0), "Fallback should have high uncertainty"
+
+        metrics = HarnessMetrics(
+            scenario="alpha_fallback",
+            backend=BACKEND,
+            grid_shape="10x9_test",
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=3,
+            n_holdout=0,
+            n_template=0,
+            mode="fallback",
+            mean_uncertainty_full=float(np.mean(pred.uncertainty_map)),
+            total_obs_in_model=s.observation_count,
+        )
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+
+class TestDeterminism:
+    """Verify that identical inputs produce identical outputs (within float tolerance)."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_identical_inputs_identical_outputs(self):
+        rpm_bins, map_bins = GRID_SHAPES["10x9_test"]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        results = []
+        for trial in range(3):
+            s = _create_surrogate(rpm_bins, map_bins)
+            s.seed_from_template(ve_surface, rpm_bins, map_bins)
+
+            obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=30, seed=42)
+            for o in obs:
+                _add_observation(s, o["rpm"], o["map_kpa"], o["ve"])
+
+            pred = _predict_full_map(s)
+            results.append(pred.ve_map.copy())
+
+        # Compare all pairs
+        for i in range(1, len(results)):
+            max_diff = float(np.max(np.abs(results[0] - results[i])))
+            # Note: sklearn GP with optimizer restarts may not be bit-identical.
+            # Record the actual drift so numpy backend can improve on it.
+            print(f"\n  Determinism trial 0 vs {i}: max_diff = {max_diff:.6e}")
+
+            # Loose tolerance for sklearn (optimizer has randomness)
+            # Numpy backend should achieve max_diff == 0.0
+            assert max_diff < 1.0, (
+                f"Excessive non-determinism: max_diff={max_diff:.6e} (budget: <1.0 VE%)"
+            )
+
+
+class TestCapSizeTraining:
+    """Scenario: Exercise GP at observation cap (~150 points).
+
+    This is the largest Cholesky the system will ever compute.
+    Tests accuracy and latency at the documented _MAX_OBS_FOR_REFIT boundary.
+    """
+
+    pytestmark = pytest.mark.validation
+
+    @pytest.mark.parametrize("grid_name", ["11x5_production", "16x16_budget"])
+    def test_cap_size_accuracy_and_latency(self, grid_name):
+        from dynoai_v3.gp_surrogate import _MAX_OBS_FOR_REFIT
+
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        # Generate observations near the cap
+        n_obs = min(_MAX_OBS_FOR_REFIT, 150)
+        all_obs = _generate_observations(
+            ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=303,
+        )
+        train, holdout = _holdout_split(all_obs, holdout_fraction=0.2)
+
+        s = _create_surrogate(rpm_bins, map_bins)
+        for obs in train:
+            _add_observation(s, obs["rpm"], obs["map_kpa"], obs["ve"], pull_number=1)
+
+        # Time the fit (first prediction triggers it)
+        t0 = time.perf_counter()
+        pred = _predict_full_map(s)
+        first_fit_ms = (time.perf_counter() - t0) * 1000
+
+        # Time cached prediction
+        timings = []
+        for _ in range(5):
+            t0 = time.perf_counter()
+            _ = _predict_full_map(s)
+            timings.append((time.perf_counter() - t0) * 1000)
+        cached_ms = float(np.median(timings))
+
+        # Holdout accuracy
+        errors = []
+        for obs in holdout:
+            r, m = obs["grid_r"], obs["grid_m"]
+            predicted = pred.ve_map[r, m]
+            actual = ve_surface[r, m]
+            errors.append(predicted - actual)
+
+        errors = np.array(errors)
+        mae = float(np.mean(np.abs(errors)))
+        rmse = float(np.sqrt(np.mean(errors**2)))
+        max_err = float(np.max(np.abs(errors)))
+
+        metrics = HarnessMetrics(
+            scenario="cap_size_training",
+            backend=BACKEND,
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=len(train),
+            n_holdout=len(holdout),
+            n_template=0,
+            mode="normal_fit",
+            mae=mae,
+            rmse=rmse,
+            max_error=max_err,
+            predict_full_map_ms=first_fit_ms,
+            refit_ms=s._last_fit_time_ms,
+            total_obs_in_model=s.observation_count,
+        )
+
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+        print(f"  cached predict: {cached_ms:.1f}ms")
+        print(f"  train size: {len(train)} (cap: {_MAX_OBS_FOR_REFIT})")
+
+        assert mae < 5.0, f"Cap-size MAE too high: {mae:.4f}"
+        assert first_fit_ms < 5000, f"Cap-size first fit too slow: {first_fit_ms:.0f}ms"
+        assert cached_ms < 10, f"Cap-size cached predict too slow: {cached_ms:.1f}ms"
+
+
+class TestNumpyBackendAB:
+    """A/B comparison: Run key scenarios with numpy backend through VESurrogate.
+
+    Validates that the numpy backend produces correct results when wired
+    through the full surrogate pipeline (normalization, template handling,
+    observation management, predict_full_map).
+    """
+
+    pytestmark = pytest.mark.validation
+
+    def _create_numpy_surrogate(self, rpm_bins, map_bins, engine_family="m8_114"):
+        from dynoai_v3.gp_surrogate import VESurrogate
+        return VESurrogate(rpm_bins, map_bins, engine_family, backend="numpy")
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_numpy_template_plus_real_accuracy(self, grid_name):
+        """Numpy backend: template + real data holdout accuracy."""
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        n_obs = min(80, len(rpm_bins) * len(map_bins) * 2)
+        all_obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs)
+        train, holdout = _holdout_split(all_obs)
+
+        s = self._create_numpy_surrogate(rpm_bins, map_bins)
+        s.seed_from_template(ve_surface, rpm_bins, map_bins)
+        for obs in train:
+            _add_observation(s, obs["rpm"], obs["map_kpa"], obs["ve"], pull_number=1)
+
+        t0 = time.perf_counter()
+        pred = _predict_full_map(s)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        errors = []
+        for obs in holdout:
+            r, m = obs["grid_r"], obs["grid_m"]
+            errors.append(pred.ve_map[r, m] - ve_surface[r, m])
+
+        errors = np.array(errors)
+        mae = float(np.mean(np.abs(errors)))
+        rmse = float(np.sqrt(np.mean(errors**2)))
+        max_err = float(np.max(np.abs(errors)))
+
+        metrics = HarnessMetrics(
+            scenario="numpy_template_plus_real",
+            backend="numpy",
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=len(train),
+            n_holdout=len(holdout),
+            n_template=len(rpm_bins) * len(map_bins),
+            mode="normal_fit",
+            mae=mae,
+            rmse=rmse,
+            max_error=max_err,
+            predict_full_map_ms=elapsed_ms,
+            refit_ms=s._last_fit_time_ms,
+            total_obs_in_model=s.observation_count,
+            template_obs_in_model=s.template_observation_count,
+        )
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+        assert mae < 5.0, f"Numpy MAE too high: {mae:.4f}"
+        assert pred.ve_map.shape == (len(rpm_bins), len(map_bins))
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_numpy_real_only_accuracy(self, grid_name):
+        """Numpy backend: real data only holdout accuracy."""
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        n_obs = min(120, len(rpm_bins) * len(map_bins) * 3)
+        all_obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=77)
+        train, holdout = _holdout_split(all_obs)
+
+        s = self._create_numpy_surrogate(rpm_bins, map_bins)
+        for obs in train:
+            _add_observation(s, obs["rpm"], obs["map_kpa"], obs["ve"], pull_number=1)
+
+        pred = _predict_full_map(s)
+
+        errors = []
+        for obs in holdout:
+            r, m = obs["grid_r"], obs["grid_m"]
+            errors.append(pred.ve_map[r, m] - ve_surface[r, m])
+
+        errors = np.array(errors)
+        mae = float(np.mean(np.abs(errors)))
+
+        metrics = HarnessMetrics(
+            scenario="numpy_real_only",
+            backend="numpy",
+            grid_shape=grid_name,
+            n_rpm=len(rpm_bins),
+            n_map=len(map_bins),
+            n_train=len(train),
+            n_holdout=len(holdout),
+            n_template=0,
+            mode="normal_fit",
+            mae=mae,
+            rmse=float(np.sqrt(np.mean(errors**2))),
+            max_error=float(np.max(np.abs(errors))),
+            predict_full_map_ms=None,
+            refit_ms=s._last_fit_time_ms,
+            total_obs_in_model=s.observation_count,
+        )
+        _all_metrics.append(metrics)
+        print(f"\n{metrics.summary()}")
+
+        assert mae < 10.0, f"Numpy MAE too high: {mae:.4f}"
+
+    def test_numpy_template_passthrough(self):
+        """Numpy backend: template-only returns exact seed table."""
+        rpm_bins, map_bins = GRID_SHAPES["11x5_production"]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        s = self._create_numpy_surrogate(rpm_bins, map_bins)
+        s.seed_from_template(ve_surface, rpm_bins, map_bins)
+
+        pred = _predict_full_map(s)
+        np.testing.assert_array_equal(pred.ve_map, ve_surface)
+
+    def test_numpy_determinism(self):
+        """Numpy backend through VESurrogate: bit-identical across trials."""
+        rpm_bins, map_bins = GRID_SHAPES["10x9_test"]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        results = []
+        for _ in range(3):
+            s = self._create_numpy_surrogate(rpm_bins, map_bins)
+            s.seed_from_template(ve_surface, rpm_bins, map_bins)
+            obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=30, seed=42)
+            for o in obs:
+                _add_observation(s, o["rpm"], o["map_kpa"], o["ve"])
+            pred = _predict_full_map(s)
+            results.append(pred.ve_map.copy())
+
+        for i in range(1, len(results)):
+            max_diff = float(np.max(np.abs(results[0] - results[i])))
+            print(f"\n  Numpy determinism trial 0 vs {i}: max_diff = {max_diff:.6e}")
+            assert max_diff == 0.0, f"Numpy not bit-identical: {max_diff}"
+
+    @pytest.mark.parametrize("grid_name", ["11x5_production", "16x16_budget"])
+    def test_numpy_latency(self, grid_name):
+        """Numpy backend: fit + predict within contract."""
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        s = self._create_numpy_surrogate(rpm_bins, map_bins)
+        s.seed_from_template(ve_surface, rpm_bins, map_bins)
+        obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=100, seed=55)
+        for o in obs:
+            _add_observation(s, o["rpm"], o["map_kpa"], o["ve"])
+
+        # First call triggers fit
+        t0 = time.perf_counter()
+        _ = _predict_full_map(s)
+        first_ms = (time.perf_counter() - t0) * 1000
+
+        # Cached calls
+        timings = []
+        for _ in range(10):
+            t0 = time.perf_counter()
+            _ = _predict_full_map(s)
+            timings.append((time.perf_counter() - t0) * 1000)
+        cached_ms = float(np.median(timings))
+
+        print(f"\n  Numpy latency [{grid_name}]: first={first_ms:.1f}ms, cached={cached_ms:.2f}ms")
+
+        # Numpy contract: first fit < 10ms, cached < 2ms
+        assert first_ms < 50, f"First fit too slow: {first_ms:.1f}ms"
+        assert cached_ms < 5, f"Cached predict too slow: {cached_ms:.2f}ms"
+
+    @pytest.mark.parametrize("grid_name", list(GRID_SHAPES.keys()))
+    def test_numpy_vs_sklearn_mean_agreement(self, grid_name):
+        """Key A/B: numpy and sklearn predictions on same data should be close.
+
+        Note: sklearn optimizes hyperparameters, numpy uses frozen values,
+        so predictions won't match exactly. We verify they're in the same
+        ballpark (< 3 VE% MAE between backends).
+        """
+        from dynoai_v3.gp_surrogate import VESurrogate
+
+        rpm_bins, map_bins = GRID_SHAPES[grid_name]
+        ve_surface = _make_ve_surface(rpm_bins, map_bins)
+
+        n_obs = min(60, len(rpm_bins) * len(map_bins) * 2)
+        obs = _generate_observations(ve_surface, rpm_bins, map_bins, n_obs=n_obs, seed=888)
+
+        # sklearn
+        s_sk = VESurrogate(rpm_bins, map_bins, "m8_114", backend="sklearn")
+        for o in obs:
+            _add_observation(s_sk, o["rpm"], o["map_kpa"], o["ve"])
+        pred_sk = _predict_full_map(s_sk)
+
+        # numpy
+        s_np = VESurrogate(rpm_bins, map_bins, "m8_114", backend="numpy")
+        for o in obs:
+            _add_observation(s_np, o["rpm"], o["map_kpa"], o["ve"])
+        pred_np = _predict_full_map(s_np)
+
+        diff = pred_sk.ve_map - pred_np.ve_map
+        mae = float(np.mean(np.abs(diff)))
+        max_diff = float(np.max(np.abs(diff)))
+
+        print(f"\n  sklearn vs numpy [{grid_name}]: MAE={mae:.4f}, max_diff={max_diff:.4f}")
+
+        # Loose: sklearn optimizes hyperparams, numpy freezes them
+        assert mae < 3.0, f"Backend disagreement too large: MAE={mae:.4f}"
+
+
+# ---------------------------------------------------------------------------
+# Final report — prints summary of all metrics after all tests
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def _print_final_report(request):
+    """Print full metrics report after all tests complete."""
+    def _report():
+        if not _all_metrics:
+            return
+        print("\n")
+        print("=" * 78)
+        print("GP HOLDOUT HARNESS — FULL METRICS REPORT")
+        print(f"Backend: {BACKEND}")
+        print(f"Scenarios run: {len(_all_metrics)}")
+        print("=" * 78)
+
+        for m in _all_metrics:
+            print(f"\n{m.summary()}")
+
+        # Summary table for holdout accuracy scenarios
+        accuracy_runs = [m for m in _all_metrics if m.mae is not None]
+        if accuracy_runs:
+            print("\n" + "-" * 60)
+            print("HOLDOUT ACCURACY SUMMARY")
+            print(f"{'Scenario':<25} {'Grid':<15} {'MAE':>8} {'RMSE':>8} {'MaxErr':>8}")
+            print("-" * 60)
+            for m in accuracy_runs:
+                print(f"{m.scenario:<25} {m.grid_shape:<15} {m.mae:>8.4f} {m.rmse:>8.4f} {m.max_error:>8.4f}")
+
+        # Latency summary
+        latency_runs = [m for m in _all_metrics if m.predict_full_map_ms is not None]
+        if latency_runs:
+            print("\n" + "-" * 60)
+            print("LATENCY SUMMARY")
+            print(f"{'Scenario':<25} {'Grid':<15} {'predict_ms':>12} {'refit_ms':>12}")
+            print("-" * 60)
+            for m in latency_runs:
+                refit = f"{m.refit_ms:.1f}" if m.refit_ms is not None else "—"
+                pred = f"{m.predict_full_map_ms:.1f}" if m.predict_full_map_ms is not None else "—"
+                print(f"{m.scenario:<25} {m.grid_shape:<15} {pred:>12} {refit:>12}")
+
+        print("\n" + "=" * 78)
+
+    request.addfinalizer(_report)

--- a/tests/test_v3_modules.py
+++ b/tests/test_v3_modules.py
@@ -243,7 +243,7 @@ class TestGPSurrogate:
         assert pred.ve_map.shape == (len(RPM_BINS), len(MAP_BINS))
         assert pred.uncertainty_map.shape == pred.ve_map.shape
         assert pred.confidence_map.shape == pred.ve_map.shape
-        assert pred.predict_time_ms > 0
+        assert pred.predict_time_ms >= 0
 
     def test_template_seeding(self):
         """Template seeding reduces initial uncertainty."""

--- a/tests/test_v3_modules.py
+++ b/tests/test_v3_modules.py
@@ -18,7 +18,9 @@ import pytest
 # ---------------------------------------------------------------------------
 # Standard V-twin test grid
 # ---------------------------------------------------------------------------
-RPM_BINS = np.array([1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500], dtype=np.float64)
+RPM_BINS = np.array(
+    [1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000, 5500], dtype=np.float64
+)
 MAP_BINS = np.array([30, 40, 50, 60, 70, 80, 90, 100, 105], dtype=np.float64)
 
 
@@ -44,10 +46,13 @@ def _synthetic_pull_data(rpm_center, map_center, n_points=5, noise=0.3):
     rng = np.random.RandomState(int(rpm_center + map_center))
     rpm = rpm_center + rng.randn(n_points) * 100
     map_kpa = map_center + rng.randn(n_points) * 5
-    ve = _synthetic_ve_table()[
-        np.searchsorted(RPM_BINS, rpm_center) - 1,
-        np.searchsorted(MAP_BINS, map_center) - 1,
-    ] + rng.randn(n_points) * noise
+    ve = (
+        _synthetic_ve_table()[
+            np.searchsorted(RPM_BINS, rpm_center) - 1,
+            np.searchsorted(MAP_BINS, map_center) - 1,
+        ]
+        + rng.randn(n_points) * noise
+    )
     return rpm, map_kpa, ve
 
 
@@ -59,7 +64,8 @@ class TestPhysicsConstraints:
 
     def test_load_defaults(self):
         """Default constraints load for all known families."""
-        from dynoai_v3.physics_constraints import PhysicsConstraints, KNOWN_FAMILIES
+        from dynoai_v3.physics_constraints import KNOWN_FAMILIES, PhysicsConstraints
+
         for family in KNOWN_FAMILIES:
             pc = PhysicsConstraints(family)
             assert pc.maps.engine_family == family
@@ -69,12 +75,14 @@ class TestPhysicsConstraints:
     def test_unknown_family_raises(self):
         """Unknown engine family raises ValueError."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         with pytest.raises(ValueError, match="Unknown engine family"):
             PhysicsConstraints("turbocharged_inline_6")
 
     def test_check_point_safe(self):
         """Normal operating point passes all checks."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("m8_114")
         verdict = pc.check_point(rpm=3500, map_kpa=80, timing=22.0, afr=12.8)
         assert verdict.safe
@@ -83,6 +91,7 @@ class TestPhysicsConstraints:
     def test_check_point_lean_wot(self):
         """Lean AFR at WOT fails safety check."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("m8_114")
         verdict = pc.check_point(rpm=3500, map_kpa=100, afr=14.0)
         assert not verdict.safe
@@ -91,6 +100,7 @@ class TestPhysicsConstraints:
     def test_check_point_over_rpm(self):
         """RPM above max test RPM fails."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("m8_114")
         verdict = pc.check_point(rpm=6500, map_kpa=100)
         assert not verdict.safe
@@ -98,6 +108,7 @@ class TestPhysicsConstraints:
     def test_is_safe_to_test(self):
         """Pre-pull safety check works."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("m8_114")
         safe, reason = pc.is_safe_to_test(3500, 90)
         assert safe
@@ -110,6 +121,7 @@ class TestPhysicsConstraints:
     def test_clamp_ve_table(self):
         """VE table clamping enforces bounds."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("m8_114")
         table = np.full((10, 9), 10.0)  # 10% correction — over the ±7% limit
         clamped, events = pc.clamp_ve_table(table)
@@ -119,6 +131,7 @@ class TestPhysicsConstraints:
     def test_adaptive_clamp_tighter(self):
         """Adaptive clamping uses tighter limits than standard."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("m8_114")
         table = np.full((10, 9), 6.0)
         _, events_std = pc.clamp_ve_table(table, is_adaptive=False)
@@ -128,6 +141,7 @@ class TestPhysicsConstraints:
     def test_export_and_reload(self):
         """Constraints survive JSON round-trip."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         with tempfile.TemporaryDirectory() as tmpdir:
             pc = PhysicsConstraints("m8_114")
             path = pc.export_to_json(Path(tmpdir) / "m8_114_limits.json")
@@ -140,13 +154,15 @@ class TestPhysicsConstraints:
     def test_cooling_type_affects_limits(self):
         """Different cooling types produce different thermal limits."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
-        air = PhysicsConstraints("m8_114")     # Air-cooled
+
+        air = PhysicsConstraints("m8_114")  # Air-cooled
         liquid = PhysicsConstraints("revmax_1250")  # Liquid-cooled
         assert air.maps.ect_enrichment_trigger_f > liquid.maps.ect_enrichment_trigger_f
 
     def test_revmax_975_constraints(self):
         """RevMax 975 (Nightster) has liquid cooling and high redline range."""
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("revmax_975")
         assert pc.maps.cooling_type == "liquid"
         assert pc.maps.max_test_rpm >= 8000
@@ -162,6 +178,7 @@ class TestGPSurrogate:
     def test_init(self):
         """Surrogate initializes without data."""
         from dynoai_v3.gp_surrogate import VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         assert not s.is_fitted
         assert s.observation_count == 0
@@ -169,6 +186,7 @@ class TestGPSurrogate:
     def test_unfitted_prediction(self):
         """Unfitted model returns high uncertainty."""
         from dynoai_v3.gp_surrogate import VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         pred = s.predict(3500, 90)
         assert pred.uncertainty >= 5.0
@@ -176,11 +194,14 @@ class TestGPSurrogate:
 
     def test_add_observations_and_fit(self):
         """Adding observations marks model stale; fit happens on first prediction."""
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         assert not s.is_fitted
         for rpm in [2500, 3000, 3500, 4000, 4500]:
-            s.add_observation(Observation(rpm=rpm, map_kpa=100, ve_delta=85.0 + rpm / 5000))
+            s.add_observation(
+                Observation(rpm=rpm, map_kpa=100, ve_delta=85.0 + rpm / 5000)
+            )
         assert s.observation_count == 5
         assert s._stale  # Model is marked stale, not yet fitted
         # First prediction triggers lazy fit
@@ -190,7 +211,8 @@ class TestGPSurrogate:
 
     def test_prediction_near_data(self):
         """Predictions near measured data have low uncertainty."""
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         for rpm in [2500, 3000, 3500, 4000, 4500]:
             s.add_observation(Observation(rpm=rpm, map_kpa=100, ve_delta=95.0))
@@ -200,7 +222,8 @@ class TestGPSurrogate:
 
     def test_prediction_far_from_data(self):
         """Predictions far from data have high uncertainty."""
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         # Only add data at WOT
         for rpm in [2500, 3000, 3500, 4000, 4500]:
@@ -212,6 +235,7 @@ class TestGPSurrogate:
     def test_add_pull_data(self):
         """Bulk pull data ingestion works; fit happens on first prediction."""
         from dynoai_v3.gp_surrogate import VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         rpm, map_kpa, ve = _synthetic_pull_data(3500, 100, n_points=10)
         n = s.add_pull_data(rpm, map_kpa, ve, pull_number=1)
@@ -225,6 +249,7 @@ class TestGPSurrogate:
     def test_rejects_extreme_data(self):
         """Extreme VE values are rejected."""
         from dynoai_v3.gp_surrogate import VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         rpm = np.array([3000, 3500, 4000])
         map_kpa = np.array([100, 100, 100])
@@ -234,7 +259,8 @@ class TestGPSurrogate:
 
     def test_predict_full_map(self):
         """Full map prediction returns correct shapes."""
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         for rpm in [2500, 3000, 3500, 4000]:
             for map_kpa in [50, 70, 90, 100]:
@@ -248,6 +274,7 @@ class TestGPSurrogate:
     def test_template_seeding(self):
         """Template seeding reduces initial uncertainty."""
         from dynoai_v3.gp_surrogate import VESurrogate
+
         # Unseeded
         s1 = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         s1.add_observation(
@@ -280,47 +307,52 @@ class TestGPSurrogate:
     def test_seed_table_returned_exactly(self):
         """When only template data exists, predict_full_map returns exact 1:1 PVV values."""
         from dynoai_v3.gp_surrogate import VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         template_ve = _synthetic_ve_table()
-        
+
         # Seed with template
         s.seed_from_template(template_ve, RPM_BINS, MAP_BINS)
-        
+
         # Predict full map (no real pull data yet)
         pred = s.predict_full_map()
-        
+
         # VE map should match template exactly (1:1)
         np.testing.assert_array_equal(pred.ve_map, template_ve)
-        
+
         # Uncertainty map should still be computed from GP
         assert pred.uncertainty_map.shape == template_ve.shape
         assert np.all(pred.uncertainty_map > 0)  # Should have some uncertainty
-    
+
     def test_seed_table_blends_with_real_data(self):
         """After adding real pull data, GP blends seed with real observations."""
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         template_ve = _synthetic_ve_table()
-        
+
         # Seed with template
         s.seed_from_template(template_ve, RPM_BINS, MAP_BINS)
-        
+
         # Add a real observation with different value
-        s.add_observation(Observation(rpm=3500, map_kpa=100, ve_delta=99.0, pull_number=1))
-        
+        s.add_observation(
+            Observation(rpm=3500, map_kpa=100, ve_delta=99.0, pull_number=1)
+        )
+
         # Predict full map
         pred = s.predict_full_map()
-        
+
         # VE map should NOT exactly match template anymore (GP blends)
         assert not np.array_equal(pred.ve_map, template_ve)
-        
+
         # But should still be close to template in most places
         diff = np.abs(pred.ve_map - template_ve)
         assert np.mean(diff) < 5.0  # Mean difference less than 5%
 
     def test_save_load_state(self):
         """Surrogate state survives JSON round-trip."""
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
+
         with tempfile.TemporaryDirectory() as tmpdir:
             s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
             for rpm in [3000, 3500, 4000]:
@@ -334,7 +366,11 @@ class TestGPSurrogate:
 
     def test_confidence_badge_mapping(self):
         """Confidence scores map to correct badges."""
-        from dynoai_v3.gp_surrogate import uncertainty_to_confidence, confidence_to_badge
+        from dynoai_v3.gp_surrogate import (
+            confidence_to_badge,
+            uncertainty_to_confidence,
+        )
+
         assert confidence_to_badge(uncertainty_to_confidence(0.3)) == "H"
         assert confidence_to_badge(uncertainty_to_confidence(0.8)) == "M"
         assert confidence_to_badge(uncertainty_to_confidence(1.5)) == "L"
@@ -342,15 +378,18 @@ class TestGPSurrogate:
 
     def test_refit_performance(self):
         """GP refit completes within performance budget."""
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         rng = np.random.RandomState(42)
         for i in range(100):
-            s.observations.append(Observation(
-                rpm=float(rng.choice(RPM_BINS)),
-                map_kpa=float(rng.choice(MAP_BINS)),
-                ve_delta=float(rng.randn() * 10 + 85),  # Mean 85%, stdev 10%
-            ))
+            s.observations.append(
+                Observation(
+                    rpm=float(rng.choice(RPM_BINS)),
+                    map_kpa=float(rng.choice(MAP_BINS)),
+                    ve_delta=float(rng.randn() * 10 + 85),  # Mean 85%, stdev 10%
+                )
+            )
         s._refit()
         assert s._last_fit_time_ms < 5000  # 5 second budget for 100 obs
 
@@ -362,9 +401,10 @@ class TestPullAdvisor:
     """Tests for pull_advisor.py"""
 
     def _make_advisor(self):
-        from dynoai_v3.gp_surrogate import VESurrogate, Observation
+        from dynoai_v3.gp_surrogate import Observation, VESurrogate
         from dynoai_v3.physics_constraints import PhysicsConstraints
         from dynoai_v3.pull_advisor import PullAdvisor
+
         s = VESurrogate(RPM_BINS, MAP_BINS, "m8_114")
         # Seed with some data
         for rpm in [3000, 4000, 5000]:
@@ -390,6 +430,7 @@ class TestPullAdvisor:
         assert len(plan) >= 3
         # First pulls should be WOT
         from dynoai_v3.pull_advisor import PullType
+
         wot_count = sum(1 for p in plan if p.pull_type == PullType.WOT_SWEEP)
         assert wot_count >= 3
 
@@ -432,7 +473,8 @@ class TestTemplateLibrary:
 
     def test_store_and_retrieve(self):
         """Templates survive store → find cycle."""
-        from dynoai_v3.template_library import TemplateLibrary, HardwareConfig
+        from dynoai_v3.template_library import HardwareConfig, TemplateLibrary
+
         with tempfile.TemporaryDirectory() as tmpdir:
             lib = TemplateLibrary(Path(tmpdir))
             config = HardwareConfig(
@@ -452,7 +494,8 @@ class TestTemplateLibrary:
 
     def test_similarity_scoring(self):
         """Similar configs score higher than dissimilar ones."""
-        from dynoai_v3.template_library import TemplateLibrary, HardwareConfig
+        from dynoai_v3.template_library import HardwareConfig, TemplateLibrary
+
         with tempfile.TemporaryDirectory() as tmpdir:
             lib = TemplateLibrary(Path(tmpdir))
 
@@ -492,7 +535,8 @@ class TestTemplateLibrary:
 
     def test_family_mismatch_returns_none(self):
         """Different engine family returns no match."""
-        from dynoai_v3.template_library import TemplateLibrary, HardwareConfig
+        from dynoai_v3.template_library import HardwareConfig, TemplateLibrary
+
         with tempfile.TemporaryDirectory() as tmpdir:
             lib = TemplateLibrary(Path(tmpdir))
             lib.store_template(
@@ -506,7 +550,8 @@ class TestTemplateLibrary:
 
     def test_count(self):
         """Template count tracks correctly."""
-        from dynoai_v3.template_library import TemplateLibrary, HardwareConfig
+        from dynoai_v3.template_library import HardwareConfig, TemplateLibrary
+
         with tempfile.TemporaryDirectory() as tmpdir:
             lib = TemplateLibrary(Path(tmpdir))
             assert lib.count() == 0
@@ -521,6 +566,7 @@ class TestTemplateLibrary:
     def test_hardware_config_signature(self):
         """Config signature is deterministic and filesystem-safe."""
         from dynoai_v3.template_library import HardwareConfig
+
         c = HardwareConfig(
             engine_family="m8_114",
             displacement_ci=114,
@@ -585,7 +631,7 @@ class TestSessionOrchestrator:
 
     def test_status_tracking(self):
         """Session status updates correctly."""
-        from dynoai_v3.session_orchestrator import TuningSession, SessionState
+        from dynoai_v3.session_orchestrator import SessionState, TuningSession
         from dynoai_v3.template_library import HardwareConfig
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -614,6 +660,7 @@ class TestBoundedOverlay:
     def _make_overlay(self):
         from dynoai_v3.adaptive_overlay import BoundedOverlay
         from dynoai_v3.physics_constraints import PhysicsConstraints
+
         pc = PhysicsConstraints("m8_114")
         base_ve = np.full((10, 9), 80.0)  # 80% VE everywhere
         return BoundedOverlay(base_ve, RPM_BINS, MAP_BINS, pc)
@@ -622,8 +669,10 @@ class TestBoundedOverlay:
         """No correction when AFR matches target."""
         overlay = self._make_overlay()
         corr = overlay.compute_fuel_correction(
-            rpm=3500, map_kpa=90,
-            current_afr=12.8, target_afr=12.8,
+            rpm=3500,
+            map_kpa=90,
+            current_afr=12.8,
+            target_afr=12.8,
             ect_f=400,
         )
         assert abs(corr) < 0.1  # Near zero with learning rate
@@ -634,8 +683,10 @@ class TestBoundedOverlay:
         # Run 10 cycles to accumulate correction
         for _ in range(10):
             corr = overlay.compute_fuel_correction(
-                rpm=3500, map_kpa=100,
-                current_afr=13.5, target_afr=12.8,
+                rpm=3500,
+                map_kpa=100,
+                current_afr=13.5,
+                target_afr=12.8,
                 ect_f=400,
             )
         assert corr > 0  # Should add fuel
@@ -647,8 +698,10 @@ class TestBoundedOverlay:
         # Drive correction hard
         for _ in range(100):
             corr = overlay.compute_fuel_correction(
-                rpm=3500, map_kpa=100,
-                current_afr=15.0, target_afr=12.0,  # Huge error
+                rpm=3500,
+                map_kpa=100,
+                current_afr=15.0,
+                target_afr=12.0,  # Huge error
                 ect_f=400,
             )
         assert abs(corr) <= max_pct + 0.01  # Within bounds
@@ -659,8 +712,10 @@ class TestBoundedOverlay:
         # Accumulate some corrections
         for _ in range(10):
             overlay.compute_fuel_correction(
-                rpm=3500, map_kpa=100,
-                current_afr=13.5, target_afr=12.8,
+                rpm=3500,
+                map_kpa=100,
+                current_afr=13.5,
+                target_afr=12.8,
                 ect_f=400,
             )
         assert overlay.enabled
@@ -672,8 +727,10 @@ class TestBoundedOverlay:
 
         # Corrections return 0 when disabled
         corr = overlay.compute_fuel_correction(
-            rpm=3500, map_kpa=100,
-            current_afr=14.0, target_afr=12.8,
+            rpm=3500,
+            map_kpa=100,
+            current_afr=14.0,
+            target_afr=12.8,
             ect_f=400,
         )
         assert corr == 0.0
@@ -683,8 +740,11 @@ class TestBoundedOverlay:
         overlay = self._make_overlay()
         for _ in range(10):
             overlay.compute_fuel_correction(
-                rpm=3500, map_kpa=100,
-                current_afr=13.5, target_afr=12.8, ect_f=400,
+                rpm=3500,
+                map_kpa=100,
+                current_afr=13.5,
+                target_afr=12.8,
+                ect_f=400,
             )
         overlay.kill_switch()
         overlay.re_enable()
@@ -695,8 +755,10 @@ class TestBoundedOverlay:
         """Knock detection retards timing."""
         overlay = self._make_overlay()
         corr = overlay.compute_timing_correction(
-            rpm=3500, map_kpa=100,
-            knock_detected=True, knock_severity=0.8,
+            rpm=3500,
+            map_kpa=100,
+            knock_detected=True,
+            knock_severity=0.8,
             ect_f=400,
         )
         assert corr < 0  # Negative = retard
@@ -705,7 +767,8 @@ class TestBoundedOverlay:
         """Timing overlay never advances beyond base."""
         overlay = self._make_overlay()
         corr = overlay.compute_timing_correction(
-            rpm=3500, map_kpa=100,
+            rpm=3500,
+            map_kpa=100,
             knock_detected=False,
         )
         assert corr <= 0.0  # Never positive
@@ -715,8 +778,11 @@ class TestBoundedOverlay:
         overlay = self._make_overlay()
         # Set a correction at hour 0
         overlay.compute_fuel_correction(
-            rpm=3500, map_kpa=100,
-            current_afr=13.5, target_afr=12.8, ect_f=400,
+            rpm=3500,
+            map_kpa=100,
+            current_afr=13.5,
+            target_afr=12.8,
+            ect_f=400,
         )
         initial_corr = overlay._fuel_corrections.copy()
         assert np.any(initial_corr != 0)
@@ -732,8 +798,10 @@ class TestBoundedOverlay:
         overlay = self._make_overlay()
         # ECT way above trigger (475°F for M8 air-cooled)
         corr = overlay.compute_fuel_correction(
-            rpm=3500, map_kpa=100,
-            current_afr=12.8, target_afr=12.8,  # AFR on target
+            rpm=3500,
+            map_kpa=100,
+            current_afr=12.8,
+            target_afr=12.8,  # AFR on target
             ect_f=500,  # Over the 475°F trigger
         )
         # Should still have positive correction due to ECT override
@@ -743,8 +811,11 @@ class TestBoundedOverlay:
         """All corrections are logged."""
         overlay = self._make_overlay()
         overlay.compute_fuel_correction(
-            rpm=3500, map_kpa=100,
-            current_afr=13.5, target_afr=12.8, ect_f=400,
+            rpm=3500,
+            map_kpa=100,
+            current_afr=13.5,
+            target_afr=12.8,
+            ect_f=400,
         )
         log = overlay.export_correction_log()
         assert len(log) == 1
@@ -764,8 +835,11 @@ class TestBoundedOverlay:
         # Add correction → table changes
         for _ in range(10):
             overlay.compute_fuel_correction(
-                rpm=3500, map_kpa=100,
-                current_afr=13.5, target_afr=12.8, ect_f=400,
+                rpm=3500,
+                map_kpa=100,
+                current_afr=13.5,
+                target_afr=12.8,
+                ect_f=400,
             )
         corrected = overlay.get_corrected_ve_table()
         assert not np.array_equal(corrected, base)
@@ -775,8 +849,11 @@ class TestBoundedOverlay:
         overlay = self._make_overlay()
         for _ in range(5):
             overlay.compute_fuel_correction(
-                rpm=3500, map_kpa=100,
-                current_afr=13.5, target_afr=12.8, ect_f=400,
+                rpm=3500,
+                map_kpa=100,
+                current_afr=13.5,
+                target_afr=12.8,
+                ect_f=400,
             )
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "overlay_state.json"
@@ -804,7 +881,7 @@ class TestEndToEnd:
         4. Finalize and store template
         5. Start NEW session — verify template match speeds things up
         """
-        from dynoai_v3 import TuningSession, HardwareConfig
+        from dynoai_v3 import HardwareConfig, TuningSession
 
         with tempfile.TemporaryDirectory() as tmpdir:
             templates_dir = Path(tmpdir) / "templates"
@@ -856,10 +933,10 @@ class TestEndToEnd:
             similar_config = HardwareConfig(
                 engine_family="m8_114",
                 displacement_ci=114,
-                cam_spec="s&s_475",      # Same cams
-                exhaust_type="slip_on",   # Different exhaust
+                cam_spec="s&s_475",  # Same cams
+                exhaust_type="slip_on",  # Different exhaust
                 air_cleaner="high_flow",  # Same
-                compression_ratio=10.5,   # Same
+                compression_ratio=10.5,  # Same
             )
             session3 = TuningSession(similar_config, templates_dir, constraints_dir)
             init3 = session3.initialize()


### PR DESCRIPTION
## Summary
- Replace sklearn `GaussianProcessRegressor` with pure NumPy `MaternGP` engine using frozen Matern 5/2 hyperparameters, eliminating optimizer non-determinism and reducing fit latency by 60-140x
- Patch axios 1.13.4 → 1.13.5 to fix DoS vulnerability (GHSA-43fc-jf86-j433)
- Add 79 tests: math parity, holdout validation, A/B comparison, edge cases — all passing

## Performance
| Metric | sklearn | numpy |
|--------|---------|-------|
| Fit (150 obs) | 112-203ms | **0.86ms** |
| Predict (16x16) | 1.2ms | **1.84ms** |
| Determinism | 4e-7 drift | **bit-identical (0.0)** |
| MAE vs sklearn | — | **< 0.3 VE%** |

## Files changed (6)
- `dynoai/core/gp_engine.py` — new pure NumPy GP engine (~220 lines)
- `dynoai_v3/gp_surrogate.py` — backend flag, numpy/sklearn dispatch
- `tests/conftest.py` — BLAS thread pinning for determinism
- `tests/test_gp_engine_parity.py` — 32 parity tests (numpy vs sklearn)
- `tests/test_gp_holdout_harness.py` — 33 holdout validation tests
- `tests/test_v3_modules.py` — timer assertion fix for Windows
- `frontend/package-lock.json` — axios security patch

## Test plan
- [x] All 79 GP tests pass (`pytest tests/test_gp_engine_parity.py tests/test_gp_holdout_harness.py tests/test_v3_modules.py::TestGPSurrogate`)
- [ ] Verify on real dyno session through CommandCenter
- [ ] Validate frozen hyperparameters [0.3, 0.3] on production dyno logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)