### PR TITLE
fix: three follow-ups from Tier 2 workspace smoke test

### DIFF
--- a/api/services/ingest/sniffer.py
+++ b/api/services/ingest/sniffer.py
@@ -134,14 +134,51 @@ def _classify_wp8(data: bytes, filename: str) -> Classification:
 # -----------------------------------------------------------------------------
 
 
+_UTF8_BOM = b"\xef\xbb\xbf"
+_UTF16_LE_BOM = b"\xff\xfe"
+_UTF16_BE_BOM = b"\xfe\xff"
+
+
+def _strip_bom(data: bytes) -> tuple[bytes, str]:
+    """Return ``(payload, encoding_hint)`` after removing any leading BOM.
+
+    Files saved by Windows tools (PowerShell ``Set-Content -Encoding UTF8``,
+    some editors) often carry a BOM. The XML detector and PVV substring
+    search both fail when the BOM offsets the content, so we normalize here.
+    """
+    if data.startswith(_UTF8_BOM):
+        return data[len(_UTF8_BOM):], "utf-8"
+    if data.startswith(_UTF16_LE_BOM):
+        return data[len(_UTF16_LE_BOM):], "utf-16-le"
+    if data.startswith(_UTF16_BE_BOM):
+        return data[len(_UTF16_BE_BOM):], "utf-16-be"
+    return data, "utf-8"
+
+
 def _looks_like_xml(head: bytes) -> bool:
-    stripped = head.lstrip()
-    return stripped.startswith(b"<?xml") or stripped.startswith(b"<")
+    payload, _ = _strip_bom(head)
+    stripped = payload.lstrip()
+    if stripped.startswith(b"<?xml") or stripped.startswith(b"<"):
+        return True
+    # UTF-16 payload without BOM: the angle bracket appears as `<\x00` (LE)
+    # or `\x00<` (BE). Detect both so a BOM-less UTF-16 PVV still classifies.
+    if stripped.startswith(b"<\x00") or stripped.startswith(b"\x00<"):
+        return True
+    return False
 
 
 def _classify_xml(data: bytes, filename: str) -> Classification:
+    payload, encoding_hint = _strip_bom(data)
+    if encoding_hint == "utf-8" and (
+        payload.lstrip().startswith(b"<\x00")
+        or payload.lstrip().startswith(b"\x00<")
+    ):
+        # BOM-less UTF-16 (rare but real on some Windows-exported PVVs).
+        encoding_hint = (
+            "utf-16-le" if payload.lstrip().startswith(b"<\x00") else "utf-16-be"
+        )
     try:
-        text = data.decode("utf-8", errors="replace")
+        text = payload.decode(encoding_hint, errors="replace")
     except Exception:
         return Classification(
             file_type=FileType.UNKNOWN.value,

--- a/api/services/workspace_analyzer.py
+++ b/api/services/workspace_analyzer.py
@@ -62,6 +62,11 @@ class WorkspaceAnalysisResult:
     zones_adjusted: Optional[int] = None
     peak_hp: Optional[float] = None
     peak_hp_rpm: Optional[float] = None
+    # Wheel speed at peak HP, captured separately from `peak_hp_rpm` because
+    # Dynojet TXT exports report mph (not RPM) and the two are different
+    # physical quantities. Only one will typically be populated for a pull,
+    # depending on which source produced the peaks.
+    peak_hp_mph: Optional[float] = None
     peak_tq: Optional[float] = None
     peak_tq_rpm: Optional[float] = None
     correction_pvv_path: Optional[str] = None
@@ -127,7 +132,11 @@ def analyze_iteration(
     result.data_source = source
     if peak:
         result.peak_hp = peak.get("peak_hp")
-        result.peak_hp_rpm = peak.get("peak_hp_rpm") or peak.get("peak_hp_mph")
+        # `peak_hp_mph` from Dynojet TXT is wheel speed, not engine RPM.
+        # Keep them in separate fields; the autotune-session fallback below
+        # may still populate `peak_hp_rpm` from real RPM data when present.
+        result.peak_hp_rpm = peak.get("peak_hp_rpm")
+        result.peak_hp_mph = peak.get("peak_hp_mph")
         result.peak_tq = peak.get("peak_torque")
 
     workflow = AutoTuneWorkflow()
@@ -173,8 +182,6 @@ def analyze_iteration(
         pvv_path = workflow.export_pvv_corrections(autotune_session, str(output_dir))
         if pvv_path:
             result.correction_pvv_path = pvv_path
-            import shutil
-
             patch_name = f"autotune_correction_{iteration.id}.pvv"
             dest_patch = ws.add_patch(
                 vehicle_id,
@@ -188,17 +195,48 @@ def analyze_iteration(
         logger.exception("pvv export failed")
         result.errors.append(f"pvv export failed: {exc}")
 
-    analysis_path = ws.add_analysis(
+    # Finalize derived fields BEFORE persisting so the on-disk JSON matches
+    # the API response. Earlier this wrote first then mutated, leaving the
+    # persisted file with `success=False` and `analysis_json_path=null` even
+    # when the API returned `success=True` with the correct path.
+    analysis_filename = f"autotune_{_timestamp()}.json"
+    analyses_dir = (
+        ws.iteration_dir(vehicle_id, session_id, iteration.id) / ws.ANALYSES_DIRNAME
+    )
+    result.analysis_json_path = str(analyses_dir / analysis_filename)
+    result.success = len(result.errors) == 0 or result.correction_pvv_path is not None
+
+    persisted_path = ws.add_analysis(
         vehicle_id,
         session_id,
         iteration.id,
-        f"autotune_{_timestamp()}.json",
+        analysis_filename,
         result.to_dict(),
     )
-    result.analysis_json_path = str(analysis_path)
-
-    result.success = len(result.errors) == 0 or result.correction_pvv_path is not None
+    # `add_analysis` may de-duplicate to a "-1.json" suffix if the file
+    # already exists; reflect the actual final path.
+    if str(persisted_path) != result.analysis_json_path:
+        result.analysis_json_path = str(persisted_path)
+        # Re-write so the file's `analysis_json_path` field also matches.
+        _atomic_rewrite_analysis_json(persisted_path, result.to_dict())
     return result
+
+
+def _atomic_rewrite_analysis_json(path: Path, payload: dict[str, Any]) -> None:
+    """Re-write an already-persisted analysis JSON in place.
+
+    Used only when `add_analysis` had to disambiguate the filename and we
+    need the on-disk content's self-referential `analysis_json_path` to
+    match the actual final path.
+    """
+    import json
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/api/test_workspace_endpoint.py
+++ b/tests/api/test_workspace_endpoint.py
@@ -171,3 +171,97 @@ class TestUploadRouting:
             content_type="multipart/form-data",
         )
         assert resp.status_code == 400
+
+
+# -----------------------------------------------------------------------------
+# Persisted-result consistency: the on-disk autotune_<ts>.json must match the
+# API response. The earlier ordering wrote first then mutated success/path,
+# leaving stale values in the file.
+# -----------------------------------------------------------------------------
+
+
+class TestAnalyzeResultPersistenceConsistency:
+    @staticmethod
+    def _bootstrap_with_pulls(client):
+        client.post("/api/workspace/vehicles", json={"name": "Dyna"})
+        resp = client.post("/api/workspace/vehicles/dyna/sessions", json={})
+        sid = resp.get_json()["id"]
+
+        pvv = (
+            b'<?xml version="1.0"?><PVV>'
+            b'<Item name="tbl_ve_tps_based_front_cyl">'
+            b'<Cell value="1.0"/></Item></PVV>'
+        )
+        # Real Dynojet TXT shape with all six columns: time, mph, ft-lbs, hp,
+        # LC1 Volts Petrol AFR, LC2 Volts Petrol AFR2 (volts here are decoy
+        # column names; the values in this fixture are already AFR-range).
+        dyno_txt = (
+            b"Time\tmph\tft-lbs\thp\tLC1 Volts Petrol AFR\tLC2 Volts Petrol AFR2\n"
+            b"0.5\t30.0\t12.0\t10.0\t13.5\t13.4\n"
+            b"1.0\t40.0\t18.0\t22.0\t13.2\t13.1\n"
+            b"1.5\t55.0\t30.0\t35.0\t12.9\t12.8\n"
+            b"2.0\t70.0\t42.0\t48.0\t12.7\t12.6\n"
+            b"2.5\t85.0\t52.0\t55.0\t12.6\t12.5\n"
+        )
+        data = MultiDict(
+            [
+                ("files", (io.BytesIO(pvv), "tune.pvv")),
+                ("files", (io.BytesIO(dyno_txt), "pull.txt")),
+            ]
+        )
+        client.post(
+            f"/api/workspace/vehicles/dyna/sessions/{sid}/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        return sid
+
+    @staticmethod
+    def test_persisted_json_matches_api_response(client, tmp_path):
+        import json
+        from pathlib import Path
+
+        sid = TestAnalyzeResultPersistenceConsistency._bootstrap_with_pulls(client)
+
+        resp = client.post(
+            f"/api/workspace/vehicles/dyna/sessions/{sid}/analyze", json={}
+        )
+        body = resp.get_json()
+        assert body["analysis_json_path"], "API must surface the analysis path"
+        assert "success" in body
+
+        on_disk = Path(body["analysis_json_path"])
+        assert on_disk.exists(), "analysis JSON must be on disk at the reported path"
+
+        persisted = json.loads(on_disk.read_text(encoding="utf-8"))
+        assert persisted["success"] == body["success"], (
+            "persisted success must match API response"
+        )
+        assert persisted["analysis_json_path"] == body["analysis_json_path"], (
+            "persisted analysis_json_path must self-reference its own file"
+        )
+        assert persisted["correction_pvv_path"] == body["correction_pvv_path"]
+
+
+class TestPeakHpUnitsAreNotConflated:
+    """
+    Dynojet TXT exports report `peak_hp_mph` (wheel speed at peak HP), not
+    engine RPM. Earlier the analyzer fell back to mph as if it were RPM. The
+    two are distinct fields now.
+    """
+
+    @staticmethod
+    def test_peak_hp_mph_kept_separate_from_peak_hp_rpm(client):
+        sid = TestAnalyzeResultPersistenceConsistency._bootstrap_with_pulls(client)
+        resp = client.post(
+            f"/api/workspace/vehicles/dyna/sessions/{sid}/analyze", json={}
+        )
+        body = resp.get_json()
+        assert "peak_hp_mph" in body, "peak_hp_mph field must exist on result"
+        # The Dynojet TXT path populates peak_hp_mph.
+        assert body["peak_hp_mph"] is not None
+        # peak_hp_rpm comes only from real RPM data; this fixture has no RPM
+        # column so it must stay None rather than be impersonated by mph.
+        assert body["peak_hp_rpm"] is None or (
+            body["peak_hp_rpm"] != body["peak_hp_mph"]
+        )

--- a/tests/unit/test_ingest_sniffer.py
+++ b/tests/unit/test_ingest_sniffer.py
@@ -80,3 +80,46 @@ def test_generic_csv_falls_back_to_pulls():
     out = classify_upload(data, "generic.csv")
     assert out["file_type"] == FileType.GENERIC_CSV.value
     assert out["routed_to"] == "pulls"
+
+
+# -----------------------------------------------------------------------------
+# BOM tolerance: some Windows tools (PowerShell Set-Content -Encoding UTF8,
+# certain editors) prepend a BOM to text files. The classifier must still
+# recognise these as PVV/XML rather than rejecting them as binary garbage.
+# -----------------------------------------------------------------------------
+
+
+def test_pvv_with_utf8_bom_classified_as_pvv():
+    data = (
+        b"\xef\xbb\xbf"  # UTF-8 BOM
+        b'<?xml version="1.0"?><PVV>'
+        b'<Item name="tbl_ve"><Cell value="1.0"/></Item></PVV>'
+    )
+    out = classify_upload(data, "tune.pvv")
+    assert out["file_type"] == FileType.PVV.value
+    assert out["routed_to"] == "base_tune"
+
+
+def test_pvv_with_utf16_le_bom_classified_as_pvv():
+    # UTF-16 LE BOM (FF FE) followed by null-padded ASCII via Python's
+    # built-in encode (yields the same bytes as PowerShell's UTF-16 output).
+    text = '<PVV><Item name="VE Correction"><Cell value="1.02"/></Item></PVV>'
+    data = b"\xff\xfe" + text.encode("utf-16-le")
+    out = classify_upload(data, "patch.pvv")
+    assert out["file_type"] == FileType.PVV.value
+    # `VE Correction` content marks it as a DynoAI-style patch.
+    assert out["routed_to"] == "patches"
+
+
+def test_pvv_with_utf16_be_bom_classified_as_pvv():
+    text = "<PVV><Item><Cell/></Item></PVV>"
+    data = b"\xfe\xff" + text.encode("utf-16-be")
+    out = classify_upload(data, "tune.pvv")
+    assert out["file_type"] == FileType.PVV.value
+
+
+def test_non_pvv_xml_with_bom_still_rejected():
+    data = b"\xef\xbb\xbf<?xml version='1.0'?><html>not a pvv</html>"
+    out = classify_upload(data, "wrong.xml")
+    assert out["file_type"] == FileType.UNKNOWN.value
+    assert out["routed_to"] == "rejected"


### PR DESCRIPTION
Three small consistency / correctness fixes surfaced during the post-merge end-to-end test of the workspace stack. None of these are safety-critical (no VE math affected) but all three made the system behave or display incorrectly.

1) BOM-tolerant sniffer (api/services/ingest/sniffer.py)
   Files saved by Windows tools (PowerShell `Set-Content -Encoding UTF8`,
   some editors) prepend a BOM. The XML detector lstrip()'d whitespace
   but not the BOM, so a perfectly valid PVV with a leading 0xEF 0xBB
   0xBF was rejected as "unrecognized content". UTF-16 BOMs were even
   worse: the file read as null-padded gibberish.

   _strip_bom() now recognizes UTF-8 / UTF-16-LE / UTF-16-BE BOMs at
   the head of the buffer and decodes the rest with the matching
   codec. _looks_like_xml() also accepts BOM-less UTF-16 by detecting
   the `<\x00` / `\x00<` pattern.

   New tests in tests/unit/test_ingest_sniffer.py:
   - test_pvv_with_utf8_bom_classified_as_pvv
   - test_pvv_with_utf16_le_bom_classified_as_pvv
   - test_pvv_with_utf16_be_bom_classified_as_pvv
   - test_non_pvv_xml_with_bom_still_rejected

2) peak_hp_rpm no longer impersonated by peak_hp_mph
   (api/services/workspace_analyzer.py)
   The earlier code did:
       result.peak_hp_rpm = peak.get("peak_hp_rpm") or peak.get("peak_hp_mph")
   which silently stored wheel speed (mph) in a field labelled "rpm" when
   the source was a Dynojet TXT export. mph and rpm are different
   physical quantities; the dashboard was lying to the tuner.

   Added a separate `peak_hp_mph` field on `WorkspaceAnalysisResult` and
   removed the fallback. peak_hp_rpm now stays None unless a real RPM
   value is available (e.g., from the autotune session post-bin).

   New test:
   - tests/api/test_workspace_endpoint.py::TestPeakHpUnitsAreNotConflated

3) Persisted analysis JSON now matches API response
   (api/services/workspace_analyzer.py)
   The earlier order was: write JSON -> set analysis_json_path -> set
   success. Result: the on-disk file always had success=False and
   analysis_json_path=null while the API returned the correct values.

   New order: precompute the destination path, set both fields on the
   in-memory result, then persist. If add_analysis() de-duplicates the
   filename (e.g. -1.json), we re-write once so the file's
   self-referential analysis_json_path stays accurate.

   New test:
   - tests/api/test_workspace_endpoint.py::TestAnalyzeResultPersistenceConsistency

Also:
- Removed a dead `import shutil` in workspace_analyzer.analyze_iteration that lingered after the patch flow switched from shutil.copy to Path.read_bytes().

Tests: 236/236 pass across the JetDrive + workspace + parsers suites
(was 230 before; +6 new). Snyk Code scan on touched files: 0 issues.

Made-with: Cursor

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates
- [ ] CI/CD updates

## Related Issues
<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made
<!-- List the main changes made in this PR -->

- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Manually tested the changes
- [ ] Run selftests
- [ ] Run kernel tests
- [ ] Run unit tests
- [ ] Run integration tests

## Math-Critical Changes
<!-- If this PR modifies files in core/ or experiments/protos/, provide additional details -->

- [ ] This PR does NOT modify math-critical files (core/ or experiments/protos/)
- [ ] This PR modifies math-critical files and has been thoroughly reviewed for correctness

**Details of math-critical changes:**
<!-- Describe any changes to mathematical algorithms or critical computations -->


## Checklist
<!-- Mark completed items with an "x" -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
