### PR TITLE
fix(gp_engine): apply review feedback from superseded PR #130

### DIFF
--- a/dynoai/core/gp_engine.py
+++ b/dynoai/core/gp_engine.py
@@ -137,10 +137,16 @@ class MaternGP:
             normalize_y: If True, center+scale y by mean/std before fitting,
                          and un-transform on prediction (replicates sklearn behavior).
         """
-        self.length_scales = np.asarray(
-            length_scales if length_scales is not None else DEFAULT_LENGTH_SCALES,
-            dtype=np.float64,
+        # `np.asarray` aliases its input when the input is already an
+        # ndarray, so two MaternGP() instances built without an explicit
+        # `length_scales` argument would share `DEFAULT_LENGTH_SCALES`. A
+        # `.copy()` here gives each instance its own array so in-place
+        # tweaks (e.g. for hyperparameter sweeps) can't contaminate the
+        # module-level default or sibling instances.
+        ls_source = (
+            length_scales if length_scales is not None else DEFAULT_LENGTH_SCALES
         )
+        self.length_scales = np.array(ls_source, dtype=np.float64, copy=True)
         self.signal_var = float(signal_var)
         self.noise_var = float(noise_var)
         self.jitter = float(jitter)
@@ -168,11 +174,29 @@ class MaternGP:
         """
         X = np.asarray(X_train, dtype=np.float64)
         y = np.asarray(y_train, dtype=np.float64).ravel()
-        n = X.shape[0]
 
+        # Shape validation: catch caller mistakes early with an informative
+        # error rather than letting them surface as cryptic broadcasting
+        # failures inside the kernel computation.
+        if X.ndim != 2:
+            raise ValueError(
+                f"X_train must be 2D with shape (n_samples, n_features); "
+                f"got shape={X.shape!r}"
+            )
+        n = X.shape[0]
         if n == 0:
             self._cache = None
             return
+        if X.shape[1] != self.length_scales.shape[0]:
+            raise ValueError(
+                f"X_train has {X.shape[1]} features but length_scales has "
+                f"{self.length_scales.shape[0]}; both must match"
+            )
+        if y.shape[0] != n:
+            raise ValueError(
+                f"X_train has {n} samples but y_train has {y.shape[0]}; "
+                f"both must match"
+            )
 
         # -- y normalization (center + scale) --
         if self.normalize_y:
@@ -200,7 +224,19 @@ class MaternGP:
         K[np.diag_indices(n)] += diag_add
 
         # -- Cholesky factorization --
-        L = np.linalg.cholesky(K)  # (n, n) lower triangular
+        # Wrap the LinAlgError so callers get an actionable hint about the
+        # two knobs they can adjust (jitter, noise_var) instead of a bare
+        # "Matrix is not positive definite" from numpy.
+        try:
+            L = np.linalg.cholesky(K)  # (n, n) lower triangular
+        except np.linalg.LinAlgError as exc:
+            raise RuntimeError(
+                "MaternGP.fit(): Cholesky decomposition failed. The covariance "
+                "matrix is numerically not positive definite with current "
+                f"noise_var={self.noise_var} and jitter={self.jitter}. "
+                "Try increasing one of them (jitter is a safer numerical "
+                "stabilizer; noise_var also affects model fit)."
+            ) from exc
 
         # -- Solve for alpha: K^{-1} y_norm via two triangular solves --
         # L v = y_norm  →  v = L^{-1} y_norm
@@ -253,6 +289,27 @@ class MaternGP:
 
         c = self._cache
         X_pred = np.asarray(X_pred, dtype=np.float64)
+
+        # Shape validation, same rationale as in fit(): better to fail
+        # loudly here than inside the kernel matmul.
+        if X_pred.ndim != 2:
+            raise ValueError(
+                f"X_pred must be 2D with shape (n_samples, n_features); "
+                f"got shape={X_pred.shape!r}"
+            )
+        if X_pred.shape[1] != c.length_scales.shape[0]:
+            raise ValueError(
+                f"X_pred has {X_pred.shape[1]} features but model was fitted "
+                f"with {c.length_scales.shape[0]}; both must match"
+            )
+
+        # Empty prediction set is a legitimate query shape (e.g. a caller
+        # filtered out all candidates by mask). Return same-typed empties
+        # rather than running through the kernel and producing zero-row
+        # numpy artifacts.
+        if X_pred.shape[0] == 0:
+            empty = np.empty(0, dtype=np.float64)
+            return empty, (empty.copy() if return_std else None)
 
         # -- Scale prediction inputs --
         X_pred_scaled = X_pred / c.length_scales  # (m, d)

--- a/tests/test_gp_engine_parity.py
+++ b/tests/test_gp_engine_parity.py
@@ -275,8 +275,13 @@ class TestNumpyLatency:
             f"median={median_ms:.2f}ms"
         )
 
-        # Contract: < 2ms for cached prediction
-        assert median_ms < 2.0, f"Predict too slow: {median_ms:.2f}ms (budget: 2ms)"
+        # Contract: cached prediction stays well under one-frame budget.
+        # The original 2ms threshold flagged false-positives on slower CI
+        # runners and on the 16x16 / n_train=150 corner. Codex review on
+        # PR #130 explicitly called this brittle. 10ms still rules out a
+        # real regression (e.g. accidentally re-running Cholesky every call,
+        # which would be 100x+ slower) without flapping on a busy host.
+        assert median_ms < 10.0, f"Predict too slow: {median_ms:.2f}ms (budget: 10ms)"
 
 
 class TestEdgeCases:
@@ -375,3 +380,127 @@ class TestEdgeCases:
         assert std.shape == (1024,)
         assert np.all(np.isfinite(mean))
         assert np.all(std >= 0)
+
+
+# ===========================================================================
+# Defensive guardrails added in response to PR #130 review feedback.
+#
+# These cover behaviors that the AI bots flagged but were never enforced
+# by the original tests:
+#   - Cross-instance state contamination via length_scales array aliasing
+#   - Shape validation in fit() and predict()
+#   - Cholesky failure error path
+#   - Empty X_pred edge case
+# ===========================================================================
+
+
+class TestLengthScalesIsolation:
+    """`length_scales` must not alias the module default or another instance."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_module_default_is_not_aliased_by_default_constructor(self):
+        from dynoai.core.gp_engine import DEFAULT_LENGTH_SCALES
+
+        original = DEFAULT_LENGTH_SCALES.copy()
+        gp = MaternGP()
+        # Mutating the instance copy must not change the module default.
+        gp.length_scales[0] = 99.0
+        np.testing.assert_array_equal(DEFAULT_LENGTH_SCALES, original)
+
+    def test_two_instances_do_not_share_length_scales(self):
+        a = MaternGP()
+        b = MaternGP()
+        a.length_scales[0] = 7.7
+        # b's array must be untouched.
+        assert b.length_scales[0] != 7.7
+
+    def test_caller_array_not_aliased(self):
+        custom = np.array([0.5, 0.5], dtype=np.float64)
+        gp = MaternGP(length_scales=custom)
+        # Mutating the caller's array must not change the GP's internal copy.
+        custom[0] = 99.0
+        assert gp.length_scales[0] == 0.5
+
+
+class TestShapeValidation:
+    """fit() and predict() must reject shape mismatches with clear errors."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_fit_rejects_1d_X(self):
+        gp = MaternGP()
+        with pytest.raises(ValueError, match="2D"):
+            gp.fit(np.array([0.5, 0.5, 0.5]), np.array([90.0, 91.0, 92.0]))
+
+    def test_fit_rejects_X_y_count_mismatch(self):
+        gp = MaternGP()
+        X = np.random.RandomState(0).rand(10, 2)
+        y = np.zeros(7)  # wrong count
+        with pytest.raises(ValueError, match="10 samples but y_train has 7"):
+            gp.fit(X, y)
+
+    def test_fit_rejects_feature_count_mismatch(self):
+        # length_scales defaults to shape (2,); a 3-feature X must error.
+        gp = MaternGP()
+        X = np.random.RandomState(0).rand(10, 3)
+        y = np.zeros(10)
+        with pytest.raises(ValueError, match="3 features but length_scales has 2"):
+            gp.fit(X, y)
+
+    def test_predict_rejects_1d_X(self):
+        gp = MaternGP()
+        X, y = _make_training_data(20)
+        gp.fit(X, y)
+        with pytest.raises(ValueError, match="2D"):
+            gp.predict(np.array([0.5, 0.5]))
+
+    def test_predict_rejects_feature_count_mismatch(self):
+        gp = MaternGP()
+        X, y = _make_training_data(20)
+        gp.fit(X, y)
+        with pytest.raises(ValueError, match="3 features but model was fitted with 2"):
+            gp.predict(np.random.RandomState(0).rand(5, 3))
+
+
+class TestPredictEmptyInput:
+    """Empty X_pred is a valid query shape and must not crash."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_predict_with_empty_X_returns_empty(self):
+        gp = MaternGP()
+        X, y = _make_training_data(20)
+        gp.fit(X, y)
+        mean, std = gp.predict(np.zeros((0, 2)))
+        assert mean.shape == (0,)
+        assert std is not None
+        assert std.shape == (0,)
+
+    def test_predict_with_empty_X_and_no_std(self):
+        gp = MaternGP()
+        X, y = _make_training_data(20)
+        gp.fit(X, y)
+        mean, std = gp.predict(np.zeros((0, 2)), return_std=False)
+        assert mean.shape == (0,)
+        assert std is None
+
+
+class TestCholeskyFailureMessage:
+    """An ill-conditioned matrix should surface an actionable error."""
+
+    pytestmark = pytest.mark.validation
+
+    def test_cholesky_failure_raises_with_jitter_hint(self):
+        # Build a degenerate setup: zero noise + zero jitter + duplicate
+        # training points → singular kernel matrix.
+        gp = MaternGP(
+            length_scales=np.array([0.3, 0.3]),
+            signal_var=1.0,
+            noise_var=0.0,
+            jitter=0.0,
+        )
+        X = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
+        y = np.array([90.0, 90.0, 90.0])
+        with pytest.raises(RuntimeError, match=r"jitter|noise_var"):
+            gp.fit(X, y)


### PR DESCRIPTION
PR #130 ("Add NumPy Matérn GP engine with parity tests and holdout validation harness") was opened Feb 19, 2026 and never rebased. Its work was already on main via PR #132 (`feat: migrate GP backend from sklearn to pure NumPy`, merged ~6 weeks ago) -- the diff is now functionally identical except for cosmetic style differences. Closing PR #130 directly would lose the AI bot review feedback that was attached to it, so this commit applies the genuinely-actionable items to main's existing copy of the code.

Five fixes:

1. `length_scales` cross-instance state contamination (Codex P1) `np.asarray(...)` aliases an ndarray input rather than copying. With the previous code, two `MaternGP()` instances built without an explicit `length_scales` argument shared `DEFAULT_LENGTH_SCALES`, so mutating one instance silently changed the module default and every sibling. Switched to `np.array(..., copy=True)` so each instance owns its own array. Also defends against the same bug when a caller passes their own array.

2. Predict-latency threshold relaxed (Codex P2) The original `assert pred_ms < 2.0` flagged false-positives on slower CI runners and on the `n_train=150 / 16x16` corner (we observed 2.79 ms median locally on this commit, with no actual regression). Loosened to 10 ms, which still rules out genuine regressions like accidentally re-running Cholesky inside predict() (orders-of-magnitude slower) without flapping on a busy host.

3. Shape validation in fit() and predict() (Copilot) Both methods now raise `ValueError` with an informative message when the input is 1D, has the wrong feature count, or (in fit()) has a length mismatch between X_train and y_train. Previously these surfaced as cryptic numpy broadcasting errors deep inside the kernel matmul.

4. Cholesky failure now actionable (Copilot) `np.linalg.cholesky` raising on an ill-conditioned covariance matrix used to surface as the bare numpy "Matrix is not positive definite". Wrapped in try/except so callers get a message that names the two knobs they can adjust (jitter, noise_var) along with the current values.

5. Empty X_pred edge case (Copilot) `predict(np.zeros((0, 2)))` now returns `(np.empty(0), np.empty(0))` rather than running through the kernel. Legitimate query shape e.g. when a caller filters all candidates out by mask.

Tests: 364/364 pass across the workspace, jetdrive, and GP test suites. New test classes in `tests/test_gp_engine_parity.py`:
  - TestLengthScalesIsolation (3 tests)
  - TestShapeValidation (5 tests)
  - TestPredictEmptyInput (2 tests)
  - TestCholeskyFailureMessage (1 test)

Snyk Code scan on `gp_engine.py`: 0 issues.

Skipped from the AI feedback (cosmetic / out of scope):
- `_obs` return type annotation
- `_split` micro-optimization
- `_report` writes to stdout only (could be JSON later)
- "constant y" / "invalidate" tests (already exist on main as test_constant_y, test_invalidate_clears_cache)

Made-with: Cursor

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates
- [ ] CI/CD updates

## Related Issues
<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made
<!-- List the main changes made in this PR -->

- 
- 
- 

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [ ] All existing tests pass
- [ ] Added new tests for the changes
- [ ] Manually tested the changes
- [ ] Run selftests
- [ ] Run kernel tests
- [ ] Run unit tests
- [ ] Run integration tests

## Math-Critical Changes
<!-- If this PR modifies files in core/ or experiments/protos/, provide additional details -->

- [ ] This PR does NOT modify math-critical files (core/ or experiments/protos/)
- [ ] This PR modifies math-critical files and has been thoroughly reviewed for correctness

**Details of math-critical changes:**
<!-- Describe any changes to mathematical algorithms or critical computations -->


## Checklist
<!-- Mark completed items with an "x" -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any additional notes or context about the PR here -->
