### PR TITLE
feat(f1): TuneLab autotune preview CLI + AFR bounds fix

### DIFF
--- a/.cursor/rules/dynoai-domain-expert.mdc
+++ b/.cursor/rules/dynoai-domain-expert.mdc
@@ -1,0 +1,284 @@
+---
+name: dynoai-domain-expert
+description: Provides domain knowledge for the DynoAI dyno-tuning platform — VE math, AFR targets and thresholds, JetDrive / LiveLink / Power Core / TuneLab integration surfaces, channel canonicalization, PVV exchange format, ECU calibration, zone classification, cylinder balance, and architecture ownership. Use when editing any DynoAI source file or when the user mentions: VE tables, AFR, wideband, LC-2, DLG-1, JetDrive, LiveLink, Power Core, TuneLab, PVV, WP8, WinPEP8, DynoWare, ECU calibration, cylinder balance, zone classification, autotune, calibration library, or any path under `api/`, `dynoai/`, `frontend/src/utils/veApply/`, `tools/autotune/`, or `api/services/integrations/powercore/`.
+---
+
+# DynoAI Domain Expert
+
+## Non-negotiables (read these first, every time)
+
+1. **No physics in the frontend.** All tuning-relevant math is computed server-side in Python and exposed via REST. See `.cursor/rules/no-physics-in-frontend.mdc`. Frontend files under `frontend/src/utils/veApply/` render server-computed values — they do not compute them.
+2. **Voltage → AFR conversion lives in exactly one file: `api/services/jetdrive/wideband_rescale.py`.** Every other module consumes already-canonicalized AFR values. If you find yourself writing a `volts * k + b` formula anywhere else, stop — you are about to re-introduce the class of bug the canonicalization merge (PR #148) fixed.
+3. **PVV (XML) is the exchange format across the Power Core boundary.** `generate_pvv_xml` in `api/services/powercore_integration.py` is the single writer. Every "apply" flow emits a reviewable PVV before the human flashes.
+4. **IronPython 2.7 lexicon applies to `api/services/integrations/powercore/*.py`.** These scripts ship inside Power Core's TuneLab. No f-strings, no type hints, no `pathlib`, no `requests`. `urllib2` for HTTP; `%` or `.format()` for strings; `str()` coercion instead of f-strings.
+5. **Server-side VE correction math is deterministic arithmetic.** No ML/AI in the correction path. ML is allowed only for advisory/analysis layers that do not feed directly into a `calculate_corrections` output.
+6. **Dual-cylinder requirement.** Both front and rear AFR data required before apply. Partial data blocks the apply entirely.
+
+## Architecture Overview
+
+| Layer | Stack | Root |
+|-------|-------|------|
+| REST API | Flask 3.0, SQLAlchemy, Flasgger | `api/` |
+| Frontend (UI display) | React 19, TypeScript, Vite, Tailwind, Radix/shadcn | `frontend/` |
+| Core Library | Python, NumPy, Pandas | `dynoai/` |
+| Desktop GUI | PyQt6 | `gui/` |
+| TuneLab scripts (IronPython 2.7) | Embedded in Power Core | `api/services/integrations/powercore/` |
+| Scripts / CLI | Python, PowerShell, Batch | `scripts/`, `tools/` |
+
+Version single source: `dynoai/version.py`.
+
+## Key File Ownership Map
+
+### Server-side (canonical owners of tuning concepts)
+
+| Responsibility | Owner File | Notes |
+|---|---|---|
+| VE correction math | `dynoai/core/ve_math.py` | Pure arithmetic. `VE_correction = AFR_measured / AFR_target`. |
+| Auto-tune pipeline (offline / F1) | `api/services/autotune_workflow.py` | `create_session → import_dataframe → analyze_afr → calculate_corrections → export_corrections_csv`. 11×9 grid. |
+| AFR target curve | `api/services/autotune_workflow.py::analyze_afr` | MAP-indexed curve, lines ~639–645. Referenced as `static_map_curve_v1`. |
+| Zone classification (server) | Inside `autotune_workflow.py` binning | Server is the source of truth; frontend file only displays. |
+| Confidence / clamping | `api/services/autotune_workflow.py::calculate_corrections` | Hit-count → confidence tier → clamp. |
+| Coverage metrics | `api/services/autotune_workflow.py` | Zone-weighted. |
+| VE bounds enforcement | `api/services/autotune_workflow.py` + safety gate on apply | Server enforces; frontend displays preset. |
+| Cylinder balance (real-time) | `api/services/jetdrive/jetdrive_realtime_analysis.py` | **Currently tracks one AFR error across both cylinders. Per-cylinder VE delta does NOT exist server-side yet — it's the Alternative B pre-work.** |
+| Wideband voltage → AFR | `api/services/jetdrive/wideband_rescale.py` | **SINGLE POINT OF CONVERSION. Never duplicate.** |
+| Channel canonicalization | `api/services/jetdrive/hardware.py::_live_capture_loop.on_sample` | Runs BEFORE `queue_mgr.on_sample` (post-PR #148). |
+| JetDrive UDP client (receive) | `api/services/jetdrive/jetdrive_client.py` | Production-ready. |
+| JetDrive UDP publisher (transmit) | `api/services/jetdrive/jetdrive_client.py::publish_run` | ~10% complete. Spec-compliant publisher scoped at 4–6 weeks. |
+| LiveLink (Power Core WCF pipe) | `api/services/livelink/livelink_client.py` + PowerShell sidecar | Current: PowerShell reflection bridge. Planned: compiled .NET sidecar. |
+| PVV read/write | `api/services/powercore_integration.py` | `parse_pvv_tune`, `generate_pvv_xml`, `parse_powervision_log`. |
+| TuneLab bridge (host-side menu) | `api/services/integrations/powercore/dynoai_tunelab_bridge.py` | Proven IronPython patterns — clone, don't reinvent. |
+| TuneLab preflight script | `api/services/integrations/powercore/dynoai_preflight.py` | Reference for `channels.GetFileHandles()` / `GetAllSamples()` patterns. |
+| TuneLab autotune (F1) | `api/services/integrations/powercore/dynoai_autotune.py` + `tools/autotune/tunelab_entrypoint.py` | Incoming. See `.cursor/rules/tunelab-autotune-agent.mdc`. |
+| Apply safety gates (Python mirror) | `api/services/autotune/safety_gates.py` | Mirrors `veApplyValidation.ts` SAFETY + `BlockReason` schema for CLI/backend parity. |
+| WP8 (WinPEP8 binary) parser | `api/services/parsers/wp8_parser.py` | Reverse-engineered protobuf-ish. |
+| Calibration library (reference corpus) | `dynoai_v3/calibration_library.py`, `api/services/calibration_library_service.py`, `api/routes/calibration_library.py` | PVV-derived, used for v3 blend seeding. Distinct from `data/v3_templates/`. |
+| Flask app + blueprint registration | `api/app.py` | 21 blueprints. |
+| Custom exceptions | `api/errors.py` | `@with_error_handling` decorator. |
+| Centralized config | `api/config.py` | |
+| Auth (API key) | `api/auth.py` | |
+| Rate limiting | `api/rate_limit.py` | |
+
+### Frontend (display-only — NOT physics owners)
+
+These files render server-computed values and orchestrate UI state. They must not contain tuning math. If you catch yourself computing a VE delta, AFR error, or cylinder imbalance in any of these files, stop and move the computation server-side.
+
+| File | Role (display only) |
+|---|---|
+| `frontend/src/utils/veApply/veApplyCore.ts` | Apply workflow UI state machine |
+| `frontend/src/utils/veApply/zoneClassification.ts` | Zone label rendering (server is source of truth) |
+| `frontend/src/utils/veApply/cylinderBalance.ts` | Display of server-computed imbalance metrics |
+| `frontend/src/utils/veApply/confidenceCalculator.ts` | Display of confidence tiers returned by server |
+| `frontend/src/utils/veApply/coverageCalculator.ts` | Display of coverage grade returned by server |
+| `frontend/src/utils/veApply/veBounds.ts` | Display of preset bounds; server enforces |
+| `frontend/src/utils/veApply/veApplyValidation.ts` | Client-side pre-submit sanity check; mirrored server-side in `api/services/autotune/safety_gates.py` |
+| `frontend/src/types/veApplyTypes.ts`, `frontend/src/lib/types.ts` | Shared TS types |
+| `frontend/src/lib/api.ts` | Axios client |
+| `frontend/src/App.tsx` | Route definitions |
+
+**Known violation being remediated**: `frontend/src/hooks/useJetDriveLive.ts` previously did voltage-to-AFR rescale client-side. Post-PR #148 that code is removed; do not re-add it.
+
+## Channel canonicalization
+
+JetDrive publishes raw channel names. `canonicalize_wideband_sample` runs BEFORE `queue_mgr.on_sample` and maps raw → canonical:
+
+| Raw (from DynoWare / Power Core) | Canonical (post-`wideband_rescale`) |
+|---|---|
+| `"LC2 Volts Petrol AFR1"` | `"AFR Front"` |
+| `"LC2 Volts Petrol AFR2"` | `"AFR Rear"` |
+| `"DLG-1 AFR F"` | `"AFR Front"` |
+| `"Air/Fuel Ratio 1"` | `"AFR Front"` |
+| `"Air/Fuel Ratio 2"` | `"AFR Rear"` |
+| `"WBO2 F"` | `"AFR Front"` |
+| `"WBO2 R"` | `"AFR Rear"` |
+
+Any code path that receives a `*Volts*` channel name and treats the value as AFR is broken. It means canonicalization was skipped or the value reached you from a surface that bypasses `wideband_rescale.py`. Fix the routing — do not paper over it with a local conversion.
+
+## Grid sizes — which surface uses which
+
+| Surface | Grid | File |
+|---|---|---|
+| `AutoTuneWorkflow` (offline, F1 autotune) | **11 RPM × 9 MAP = 99 cells** | `api/services/autotune_workflow.py` |
+| `RealtimeAnalysisEngine` (live JetDrive) | **20 RPM × 10 MAP = 200 cells** | `api/services/jetdrive/jetdrive_realtime_analysis.py` |
+
+Coverage percentages from one grid do NOT mean the same thing in the other. Always state which grid a metric represents when discussing coverage.
+
+## Core Concepts
+
+### VE (Volumetric Efficiency) Tables
+
+2D grid indexed by RPM (rows) and MAP/kPa (columns). Each cell holds a VE percentage representing how much of the theoretical cylinder volume actually fills with air. The ECU uses VE to calculate fuel injection pulse width.
+
+**Correction math (v2.0.0, current default):**
+```
+VE_correction = AFR_measured / AFR_target
+```
+A correction of 1.077 means +7.7% more fuel needed. Legacy v1.0.0 used `1 + (AFR_error * 0.07)`.
+
+### AFR target curve (`static_map_curve_v1`)
+
+| MAP (kPa) | AFR target |
+|---|---|
+| 20–30 | 14.7 (stoich) |
+| 40 | 14.5 |
+| 50 | 14.0 |
+| 60 | 13.5 |
+| 70 | 13.0 |
+| 80 | 12.8 |
+| 90 | 12.5 |
+| 100+ | 12.2 |
+
+Implemented inside `analyze_afr`. Referenced by name as `"static_map_curve_v1"` in downstream summary JSON. There is **no static 13.2 target** anywhere in the pipeline — if you see `"static_13.2"` in a plan or test, it's a typo for `static_map_curve_v1`. F1.1 adds `"from_tune.AFR_Target"` as a second source when AFR targets are pulled from the loaded PVV.
+
+### Zones
+
+Every VE cell belongs to a zone based on RPM and MAP coordinates:
+
+| Zone | MAP (kPa) | RPM | Weight | Typical riding |
+|------|-----------|-----|--------|----------------|
+| cruise | 31–69 | 1200–5500 | 5 | ~70% of miles |
+| partThrottle | 70–94 | 1200–5500 | 4 | Roll-on accel |
+| wot | 95+ | 1200–5500 | 2 | Full power pulls |
+| decel | ≤30 | 1200–5500 | 1 | Engine braking |
+| edge | any | <1200 or >5500 | 1 | Idle / redline |
+
+Zone determines confidence thresholds and coverage weighting.
+
+### Confidence and clamping
+
+Hit count (samples in a cell) → confidence tier → clamp limit:
+
+| Confidence | Clamp limit | Meaning |
+|---|---|---|
+| high | ±7% | Trustworthy data |
+| medium | ±5% | Some uncertainty |
+| low | ±3% | Uncertain, conservative |
+| skip | null | Below `minHits` — preserve base VE |
+
+Each zone has its own `minHits`, `mediumHits`, `highHits` thresholds (e.g., cruise needs 100 hits for high confidence).
+
+### Cylinder balance (V-twin specific)
+
+Front and rear cylinders analyzed separately:
+- **Systematic bias**: weighted average of `(rear / front - 1) * 100`. Positive = rear needs more fuel.
+- **Localized imbalance**: max absolute difference across cells.
+- Warnings at >2% systematic bias or >5% localized imbalance.
+- Both cylinders must have ≥3 hits per cell for inclusion.
+
+Per-cylinder VE delta tracking in `jetdrive_realtime_analysis.py` does NOT exist yet (pre-work #2 for Alternative B).
+
+### VE Bounds presets
+
+| Preset | Range | Enforcement | Use case |
+|---|---|---|---|
+| na_harley | 15–115% | enforce | Stock / mild cams |
+| stage_1 | 15–120% | enforce | Stage 1 cams |
+| stage_2 | 15–125% | enforce | Stage 2+ cams |
+| boosted | 10–200% | warn only | Turbo / supercharged |
+| custom | 0–999% | warn only | No enforcement |
+
+### Coverage
+
+Zone-weighted metric: `sum(sufficientCells * weight) / sum(totalCells * weight)`. Grades: A (≥90%), B (≥75%), C (≥60%), D (≥40%), F (<40%). Warns if cruise zone < 60%.
+
+## Threshold vocabulary — distinct constants
+
+If you see "the 30% rule" vs "the 25% rule" vs "the 15% rule" in conversation, these refer to different gates. Do not conflate them.
+
+| Constant | Value | Where used | Purpose |
+|---|---|---|---|
+| `MAX_CORRECTION_PCT_PER_SESSION` | ±15% (default) | Auto-tune session clamp | Hard clamp applied per cell per session — `calculate_corrections` enforces |
+| `BLOCK_THRESHOLD_PCT` | ±25% | `api/services/autotune/safety_gates.py` + `frontend/src/utils/veApply/veApplyValidation.ts` | Blocks entire apply when any included cell exceeds threshold |
+| `warn_raw_delta_pct` | 10% | `SAFETY` in `api/services/autotune/safety_gates.py` and `veApplyValidation.ts` | Preview/apply warning threshold; informational unless a block reason is present |
+
+## Safety Constraints (CRITICAL)
+
+1. **Deterministic math only** — no ML/AI in the VE correction path.
+2. **Bounded adjustments** — default max correction ±15% per session. >±25% blocks the apply entirely.
+3. **Dual-cylinder requirement** — both front and rear data required; partial data blocks apply.
+4. **VE bounds enforcement** — physical limits prevent impossible VE values.
+5. **Zero-hit cells untouched** — cells with no data always get correction = 1.0.
+6. **Convergence over perfection** — large errors corrected incrementally across multiple sessions, not in one step.
+7. **No frontend physics** — all tuning math server-side. See `.cursor/rules/no-physics-in-frontend.mdc`.
+8. **Human-review checkpoint** — PVV must be reviewable before any flash. Never auto-flash. This is liability shield AND safety rail.
+
+## Integration surfaces
+
+### Power Core / TuneLab (IronPython 2.7)
+- **Path**: `api/services/integrations/powercore/*.py`
+- **Runtime**: IronPython 2.7 embedded in Power Core
+- **Min Power Core version** for modern TuneLab API + HTTP: `2023.1.0`
+- **Lexicon rules**: no f-strings, no type hints, no `pathlib`, no `requests`. `urllib2` for HTTP; `%` or `.format()` for strings.
+- **Every TuneLab script must**: (a) check `context.PowerCoreVersion` before touching channel API, (b) handle unreachable CLI / DynoAI gracefully (MessageBox, never traceback), (c) guarantee `try/finally` temp-file cleanup, (d) use a per-invocation random temp subdir for re-entrancy safety.
+- **Sub-rule**: `.cursor/rules/tunelab-autotune-agent.mdc`.
+
+### JetDrive (UDP multicast)
+- **Path**: `api/services/jetdrive/*`
+- **Wire protocol**: UDP multicast on port `22344`
+- **Groups**: primary `224.0.2.10`; alternatives `239.255.60.60`, `224.0.0.1`, `239.192.0.1`
+- **Packet size**: up to 4096 bytes
+- **Receive path**: spec-compliant, production-ready
+- **Transmit path**: ~10% complete. Full publisher (Alternative B of Power Core bridge plan) scoped at 4–6 weeks with 3 pre-work items.
+- **Vendor reference**: Apache 2.0 at `vendor/DynojetRDTeam-jetdrive-sharp-*`.
+
+### LiveLink (WCF named pipe)
+- **Path**: `api/services/livelink/livelink_client.py` + PowerShell sidecar
+- **Protocol**: WCF over `net.pipe://localhost/SCT/LiveLinkService`
+- **Current**: PowerShell reflection bridge (fragile; breaks on Power Core updates)
+- **Planned** (Alternative C): compiled .NET sidecar with event-driven push instead of 100 ms polls
+
+### PVV (XML exchange format)
+- **Path**: `api/services/powercore_integration.py`
+- **Readers/writers**: `parse_pvv_tune`, `generate_pvv_xml`, `parse_powervision_log`
+- PVV is the single source of truth across the Power Core boundary. Every apply flow emits a reviewable PVV before flash. Never bypass.
+
+### WP8 (WinPEP8 binary)
+- **Path**: `api/services/parsers/wp8_parser.py`
+- Reverse-engineered format. Comments note "real format may vary." Harden against PTI / Night Train / 250 series variants when encountered.
+
+## Auto-tune pipeline (offline, F1)
+
+1. Import log (Power Vision CSV, JetDrive CSV, or DataFrame via `import_dataframe`)
+2. Filter signals (lowpass RC=500ms, outlier rejection at 2σ)
+3. Bin data into **11 RPM × 9 MAP = 99 cells**
+4. Calculate AFR error per cell vs `static_map_curve_v1`
+5. Convert to VE corrections with clamping (±15% default, ±25% block, confidence-weighted)
+6. Export: PVV XML, TuneLab script, CSV grids, `manifest.json`
+
+## Error Handling Patterns
+
+All Flask routes use `api/errors.py`:
+- `@with_error_handling` decorator catches exceptions
+- Custom classes: `ValidationError` (400), `NotFoundError` (404), `AnalysisError` (500), `JetDriveError` (502), etc.
+- Standardized JSON responses with request ID tracking
+
+## Test locations
+
+| Path | Owns |
+|---|---|
+| `tests/api/` | Flask route tests; auth / rate-limit / security tests |
+| `tests/unit/` | Pure-Python unit tests for `dynoai/core/`, `tools/`, `api/services/` |
+| `tests/jetdrive/` | JetDrive pipeline, canonicalization, wideband rescale |
+| `tests/tunelab/` | TuneLab autotune CLI tests (F1+) |
+
+When adding a test, match the surface. A `tools/autotune/*.py` test goes in `tests/unit/` unless the behavior is TuneLab-specific, in which case `tests/tunelab/`.
+
+Known CI gotcha: `bcrypt`-gated backend tests (`test_jwt_auth.py`, `test_runs.py`, `test_rate_limiting.py`, `test_security.py`, `test_analyze_endpoint.py`, `test_authentication.py`, `test_runs_endpoint.py`) fail locally without `bcrypt` installed. Not in `requirements*.txt` — separate hygiene issue.
+
+## Version floors
+
+| Surface | Min version | Reason |
+|---|---|---|
+| Power Core (for TuneLab) | 2023.1.0 | Modern channel API + HTTP support |
+| Python (API) | 3.11 | Flask 3.0 ecosystem |
+| Node (frontend) | 20 | Vite 5 / React 19 |
+| Flask | 3.0 | |
+| React | 19 | |
+| IronPython (TuneLab) | 2.7 | Pinned by Power Core runtime |
+
+## Cross-references
+
+- `.cursor/rules/no-physics-in-frontend.mdc` — frontend math prohibition
+- `.cursor/rules/tunelab-autotune-agent.mdc` — TuneLab module specifics
+- `architecture-map.md` — full ownership details
+- `docs/specs/ECU_CALIBRATION_MODEL.md` — ECU flashing feasibility / why DynoAI does not ship a flasher

--- a/api/routes/workspace.py
+++ b/api/routes/workspace.py
@@ -37,6 +37,12 @@ from werkzeug.utils import secure_filename
 
 from api.errors import ValidationError, with_error_handling
 from api.services.ingest.sniffer import classify_upload
+from api.services.sessions.dispatch_readiness import evaluate_dispatch_readiness
+from api.services.sessions.p0_plausibility_checker import evaluate_p0_plausibility
+from api.services.sessions.phased_pull_controller import (
+    compute_phase_snapshot,
+    mark_phase_complete,
+)
 from api.services.ingest.watcher import get_watcher
 from api.services.tuning_workspace import (
     WorkspaceError,
@@ -153,6 +159,157 @@ def patch_session(vid: str, sid: str):
     except WorkspaceError as exc:
         return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
     return jsonify(session.to_dict()), 200
+
+
+@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/v3", methods=["GET"])
+@with_error_handling
+def get_session_v3(vid: str, sid: str):
+    ws = get_workspace()
+    try:
+        session = ws.get_session(vid, sid)
+    except WorkspaceError as exc:
+        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    if not session.v3:
+        return (
+            jsonify(
+                {
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": f"session has no v3 payload: {vid}/{sid}",
+                    }
+                }
+            ),
+            404,
+        )
+    return jsonify(session.v3), 200
+
+
+@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/v3", methods=["POST"])
+@with_error_handling
+def upsert_session_v3(vid: str, sid: str):
+    ws = get_workspace()
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        raise ValidationError("v3 payload must be a JSON object")
+    payload.setdefault("schema_version", "dynoai.session.v3")
+    payload.setdefault("session_id", sid)
+    try:
+        session = ws.set_session_v3(vid, sid, payload)
+    except WorkspaceError as exc:
+        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    return jsonify(session.to_dict()), 200
+
+
+@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/v3/resolve_blocker", methods=["POST"])
+@with_error_handling
+def resolve_session_v3_blocker(vid: str, sid: str):
+    ws = get_workspace()
+    data = request.get_json(silent=True) or {}
+    field_name = (data.get("field") or "").strip()
+    if not field_name:
+        raise ValidationError("field is required")
+    try:
+        session = ws.resolve_session_v3_blocker(
+            vid,
+            sid,
+            field_name=field_name,
+            resolved_by=data.get("resolved_by"),
+            evidence=data.get("evidence"),
+        )
+    except WorkspaceError as exc:
+        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    return jsonify(session.to_dict()), 200
+
+
+@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/dispatch_readiness", methods=["GET"])
+@with_error_handling
+def get_dispatch_readiness(vid: str, sid: str):
+    ws = get_workspace()
+    try:
+        session = ws.get_session(vid, sid)
+    except WorkspaceError as exc:
+        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    status = ws.compute_status(vid, sid)
+    readiness = evaluate_dispatch_readiness(session, status)
+    return jsonify(readiness), 200
+
+
+@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/phases", methods=["GET"])
+@with_error_handling
+def get_session_phases(vid: str, sid: str):
+    ws = get_workspace()
+    try:
+        v3 = ws.get_session_v3(vid, sid)
+    except WorkspaceError as exc:
+        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    if not v3:
+        return (
+            jsonify({"error": {"code": "NOT_FOUND", "message": "session has no v3 payload"}}),
+            404,
+        )
+    return jsonify(compute_phase_snapshot(v3).to_dict()), 200
+
+
+@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/phases/complete", methods=["POST"])
+@with_error_handling
+def complete_session_phase(vid: str, sid: str):
+    ws = get_workspace()
+    data = request.get_json(silent=True) or {}
+    phase_id = (data.get("phase_id") or "").strip()
+    if not phase_id:
+        raise ValidationError("phase_id is required")
+    try:
+        v3 = ws.get_session_v3(vid, sid)
+    except WorkspaceError as exc:
+        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    if not v3:
+        return (
+            jsonify({"error": {"code": "NOT_FOUND", "message": "session has no v3 payload"}}),
+            404,
+        )
+
+    try:
+        updated_payload = mark_phase_complete(v3, phase_id)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+    ws.set_session_v3(vid, sid, updated_payload)
+    return jsonify(compute_phase_snapshot(updated_payload).to_dict()), 200
+
+
+@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/p0_plausibility", methods=["POST"])
+@with_error_handling
+def run_p0_plausibility(vid: str, sid: str):
+    ws = get_workspace()
+    data = request.get_json(silent=True) or {}
+    try:
+        session = ws.get_session(vid, sid)
+        vehicle = ws.get_vehicle(vid)
+    except WorkspaceError as exc:
+        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+
+    v3 = session.v3 or {}
+    build = v3.get("build_spec") if isinstance(v3, dict) else {}
+    known_ci = data.get("known_displacement_ci")
+    if known_ci is None and isinstance(build, dict):
+        known_ci = build.get("displacement_ci")
+    if known_ci is None:
+        known_ci = vehicle.displacement_ci
+    if known_ci is None:
+        raise ValidationError("known_displacement_ci is required")
+
+    result = evaluate_p0_plausibility(
+        known_displacement_ci=float(known_ci),
+        measured_displacement_ci=data.get("measured_displacement_ci"),
+        peak_tq_ftlb=data.get("peak_tq_ftlb"),
+        peak_tq_rpm=data.get("peak_tq_rpm"),
+        bmep_psi=data.get("bmep_psi"),
+        bsfc_lb_hp_hr=data.get("bsfc_lb_hp_hr"),
+    )
+
+    checks = v3.setdefault("checks", {})
+    checks["p0_plausibility"] = result.to_dict()
+    session = ws.set_session_v3(vid, sid, v3)
+    return jsonify({"p0_plausibility": result.to_dict(), "session": session.to_dict()}), 200
 
 
 @workspace_bp.route("/vehicles/<vid>/sessions/<sid>/status", methods=["GET"])

--- a/api/routes/workspace.py
+++ b/api/routes/workspace.py
@@ -58,6 +58,7 @@ def _not_found_error(message: str = "resource not found"):
     """Return sanitized NOT_FOUND payload without leaking internals."""
     return jsonify({"error": {"code": "NOT_FOUND", "message": message}}), 404
 
+
 # =============================================================================
 # Vehicles
 # =============================================================================

--- a/api/routes/workspace.py
+++ b/api/routes/workspace.py
@@ -37,13 +37,13 @@ from werkzeug.utils import secure_filename
 
 from api.errors import ValidationError, with_error_handling
 from api.services.ingest.sniffer import classify_upload
+from api.services.ingest.watcher import get_watcher
 from api.services.sessions.dispatch_readiness import evaluate_dispatch_readiness
 from api.services.sessions.p0_plausibility_checker import evaluate_p0_plausibility
 from api.services.sessions.phased_pull_controller import (
     compute_phase_snapshot,
     mark_phase_complete,
 )
-from api.services.ingest.watcher import get_watcher
 from api.services.tuning_workspace import (
     WorkspaceError,
     get_workspace,
@@ -200,7 +200,9 @@ def upsert_session_v3(vid: str, sid: str):
     return jsonify(session.to_dict()), 200
 
 
-@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/v3/resolve_blocker", methods=["POST"])
+@workspace_bp.route(
+    "/vehicles/<vid>/sessions/<sid>/v3/resolve_blocker", methods=["POST"]
+)
 @with_error_handling
 def resolve_session_v3_blocker(vid: str, sid: str):
     ws = get_workspace()
@@ -221,7 +223,9 @@ def resolve_session_v3_blocker(vid: str, sid: str):
     return jsonify(session.to_dict()), 200
 
 
-@workspace_bp.route("/vehicles/<vid>/sessions/<sid>/dispatch_readiness", methods=["GET"])
+@workspace_bp.route(
+    "/vehicles/<vid>/sessions/<sid>/dispatch_readiness", methods=["GET"]
+)
 @with_error_handling
 def get_dispatch_readiness(vid: str, sid: str):
     ws = get_workspace()
@@ -244,7 +248,9 @@ def get_session_phases(vid: str, sid: str):
         return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
     if not v3:
         return (
-            jsonify({"error": {"code": "NOT_FOUND", "message": "session has no v3 payload"}}),
+            jsonify(
+                {"error": {"code": "NOT_FOUND", "message": "session has no v3 payload"}}
+            ),
             404,
         )
     return jsonify(compute_phase_snapshot(v3).to_dict()), 200
@@ -264,7 +270,9 @@ def complete_session_phase(vid: str, sid: str):
         return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
     if not v3:
         return (
-            jsonify({"error": {"code": "NOT_FOUND", "message": "session has no v3 payload"}}),
+            jsonify(
+                {"error": {"code": "NOT_FOUND", "message": "session has no v3 payload"}}
+            ),
             404,
         )
 
@@ -309,7 +317,10 @@ def run_p0_plausibility(vid: str, sid: str):
     checks = v3.setdefault("checks", {})
     checks["p0_plausibility"] = result.to_dict()
     session = ws.set_session_v3(vid, sid, v3)
-    return jsonify({"p0_plausibility": result.to_dict(), "session": session.to_dict()}), 200
+    return (
+        jsonify({"p0_plausibility": result.to_dict(), "session": session.to_dict()}),
+        200,
+    )
 
 
 @workspace_bp.route("/vehicles/<vid>/sessions/<sid>/status", methods=["GET"])

--- a/api/routes/workspace.py
+++ b/api/routes/workspace.py
@@ -53,6 +53,11 @@ from api.services.workspace_analyzer import analyze_iteration
 logger = logging.getLogger(__name__)
 workspace_bp = Blueprint("workspace", __name__, url_prefix="/api/workspace")
 
+
+def _not_found_error(message: str = "resource not found"):
+    """Return sanitized NOT_FOUND payload without leaking internals."""
+    return jsonify({"error": {"code": "NOT_FOUND", "message": message}}), 404
+
 # =============================================================================
 # Vehicles
 # =============================================================================
@@ -93,8 +98,8 @@ def create_vehicle():
 def get_vehicle(vid: str):
     try:
         vehicle = get_workspace().get_vehicle(vid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     return jsonify(vehicle.to_dict()), 200
 
 
@@ -104,8 +109,8 @@ def patch_vehicle(vid: str):
     data = request.get_json(silent=True) or {}
     try:
         vehicle = get_workspace().update_vehicle(vid, **data)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     return jsonify(vehicle.to_dict()), 200
 
 
@@ -119,8 +124,8 @@ def patch_vehicle(vid: str):
 def list_sessions(vid: str):
     try:
         get_workspace().get_vehicle(vid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     sessions = get_workspace().list_sessions(vid)
     return jsonify([s.to_dict() for s in sessions]), 200
 
@@ -145,8 +150,8 @@ def create_session(vid: str):
 def get_session(vid: str, sid: str):
     try:
         session = get_workspace().get_session(vid, sid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     return jsonify(session.to_dict()), 200
 
 
@@ -156,8 +161,8 @@ def patch_session(vid: str, sid: str):
     data = request.get_json(silent=True) or {}
     try:
         session = get_workspace().update_session(vid, sid, **data)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     return jsonify(session.to_dict()), 200
 
 
@@ -167,8 +172,8 @@ def get_session_v3(vid: str, sid: str):
     ws = get_workspace()
     try:
         session = ws.get_session(vid, sid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     if not session.v3:
         return (
             jsonify(
@@ -195,8 +200,8 @@ def upsert_session_v3(vid: str, sid: str):
     payload.setdefault("session_id", sid)
     try:
         session = ws.set_session_v3(vid, sid, payload)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     return jsonify(session.to_dict()), 200
 
 
@@ -218,8 +223,8 @@ def resolve_session_v3_blocker(vid: str, sid: str):
             resolved_by=data.get("resolved_by"),
             evidence=data.get("evidence"),
         )
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     return jsonify(session.to_dict()), 200
 
 
@@ -231,8 +236,8 @@ def get_dispatch_readiness(vid: str, sid: str):
     ws = get_workspace()
     try:
         session = ws.get_session(vid, sid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     status = ws.compute_status(vid, sid)
     readiness = evaluate_dispatch_readiness(session, status)
     return jsonify(readiness), 200
@@ -244,8 +249,8 @@ def get_session_phases(vid: str, sid: str):
     ws = get_workspace()
     try:
         v3 = ws.get_session_v3(vid, sid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     if not v3:
         return (
             jsonify(
@@ -266,8 +271,8 @@ def complete_session_phase(vid: str, sid: str):
         raise ValidationError("phase_id is required")
     try:
         v3 = ws.get_session_v3(vid, sid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     if not v3:
         return (
             jsonify(
@@ -292,8 +297,8 @@ def run_p0_plausibility(vid: str, sid: str):
     try:
         session = ws.get_session(vid, sid)
         vehicle = ws.get_vehicle(vid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
 
     v3 = session.v3 or {}
     build = v3.get("build_spec") if isinstance(v3, dict) else {}
@@ -340,8 +345,8 @@ def get_session_status(vid: str, sid: str):
 def list_iterations(vid: str, sid: str):
     try:
         get_workspace().get_session(vid, sid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     iters = get_workspace().list_iterations(vid, sid)
     return jsonify([i.to_dict() for i in iters]), 200
 
@@ -372,8 +377,8 @@ def list_pulls(vid: str, sid: str, iid: str):
     ws = get_workspace()
     try:
         ws.get_iteration(vid, sid, iid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     files = ws.list_pulls(vid, sid, iid)
     return jsonify([_file_summary(p) for p in files]), 200
 
@@ -386,8 +391,8 @@ def list_patches(vid: str, sid: str, iid: str):
     ws = get_workspace()
     try:
         ws.get_iteration(vid, sid, iid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     files = ws.list_patches(vid, sid, iid)
     return jsonify([_file_summary(p) for p in files]), 200
 
@@ -400,8 +405,8 @@ def list_analyses(vid: str, sid: str, iid: str):
     ws = get_workspace()
     try:
         ws.get_iteration(vid, sid, iid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     files = ws.list_analyses(vid, sid, iid)
     return jsonify([_file_summary(p) for p in files]), 200
 
@@ -419,8 +424,8 @@ def analyze_active_iteration(vid: str, sid: str):
     iteration_id = data.get("iteration_id")
     try:
         result = analyze_iteration(vid, sid, iteration_id)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     status_code = 200 if result.success else 400
     return jsonify(result.to_dict()), status_code
 
@@ -433,8 +438,8 @@ def analyze_active_iteration(vid: str, sid: str):
 def analyze_specific_iteration(vid: str, sid: str, iid: str):
     try:
         result = analyze_iteration(vid, sid, iid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
     status_code = 200 if result.success else 400
     return jsonify(result.to_dict()), status_code
 
@@ -452,8 +457,8 @@ def upload_to_session(vid: str, sid: str):
 
     try:
         ws.get_session(vid, sid)
-    except WorkspaceError as exc:
-        return jsonify({"error": {"code": "NOT_FOUND", "message": str(exc)}}), 404
+    except WorkspaceError:
+        return _not_found_error()
 
     files = request.files.getlist("files")
     if not files:

--- a/api/services/autotune/__init__.py
+++ b/api/services/autotune/__init__.py
@@ -1,0 +1,1 @@
+"""Shared autotune service helpers."""

--- a/api/services/autotune/safety_gates.py
+++ b/api/services/autotune/safety_gates.py
@@ -1,0 +1,268 @@
+"""Shared VE apply safety checks used by frontend and CLI flows."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Literal, TypedDict
+
+EPSILON = 1e-6
+
+
+class SafetyThresholds(TypedDict):
+    """Safety and warning thresholds mirrored from veApplyValidation.ts."""
+
+    block_raw_delta_pct: float
+    warn_raw_delta_pct: float
+    warn_systematic_bias_pct: float
+    warn_localized_imbalance_pct: float
+    min_hits_for_inclusion: int
+    warn_coverage_pct: float
+
+
+SAFETY: SafetyThresholds = {
+    "block_raw_delta_pct": 25.0,
+    "warn_raw_delta_pct": 10.0,
+    "warn_systematic_bias_pct": 2.0,
+    "warn_localized_imbalance_pct": 5.0,
+    "min_hits_for_inclusion": 3,
+    "warn_coverage_pct": 50.0,
+}
+
+
+BlockReasonType = Literal[
+    "extreme_correction",
+    "missing_base",
+    "shape_mismatch",
+    "partial_cylinder",
+    "invalid_base_ve",
+    "empty_grid",
+]
+
+
+class BlockCell(TypedDict):
+    rpm: float
+    map: float
+    value: float
+
+
+class BlockReason(TypedDict, total=False):
+    type: BlockReasonType
+    message: str
+    cells: list[BlockCell]
+
+
+DualCylinderGrid = dict[str, list[list[float]]]
+
+
+def validate_correction(value: Any) -> float | None:
+    """Return a valid correction value or None for invalid input."""
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    if not math.isfinite(number):
+        return None
+    if number <= 0:
+        return None
+    return number
+
+
+def sanitize_correction(value: Any) -> float:
+    """Coerce invalid corrections to neutral multiplier 1.0."""
+    valid = validate_correction(value)
+    if valid is None:
+        return 1.0
+    return valid
+
+
+def has_active_correction(
+    correction: float,
+    hit_count: float,
+    min_hits: int = SAFETY["min_hits_for_inclusion"],
+) -> bool:
+    """A correction is active only with enough hits and non-unity value."""
+    if hit_count < min_hits:
+        return False
+    sanitized = sanitize_correction(correction)
+    return abs(sanitized - 1.0) > EPSILON
+
+
+def _axis_value(axis: list[float], idx: int) -> float:
+    if 0 <= idx < len(axis):
+        return float(axis[idx])
+    return float(idx)
+
+
+def _shape(grid: list[list[float]]) -> tuple[int, int]:
+    if not grid:
+        return (0, 0)
+    return (len(grid), len(grid[0]) if grid[0] else 0)
+
+
+def check_block_conditions(
+    base_ve: DualCylinderGrid | None,
+    corrections: DualCylinderGrid,
+    hit_counts: DualCylinderGrid,
+    rpm_axis: list[float],
+    map_axis: list[float],
+) -> list[BlockReason]:
+    """Run all apply-block conditions. Empty list means apply is allowed."""
+    blocks: list[BlockReason] = []
+
+    if not base_ve:
+        blocks.append(
+            {
+                "type": "missing_base",
+                "message": "Import a base VE table (PVV or preset) before applying corrections.",
+            }
+        )
+        return blocks
+
+    base_front = base_ve["front"]
+    if len(base_front) == 0 or len(base_front[0]) == 0:
+        blocks.append(
+            {
+                "type": "empty_grid",
+                "message": "Base VE grid is empty. Import a valid tune file.",
+            }
+        )
+        return blocks
+
+    expected_rows = len(base_front)
+    expected_cols = len(base_front[0])
+    grids = [
+        ("baseVE.front", base_ve["front"]),
+        ("baseVE.rear", base_ve["rear"]),
+        ("corrections.front", corrections["front"]),
+        ("corrections.rear", corrections["rear"]),
+        ("hitCounts.front", hit_counts["front"]),
+        ("hitCounts.rear", hit_counts["rear"]),
+    ]
+    mismatches = [
+        name
+        for name, grid in grids
+        if _shape(grid) != (expected_rows, expected_cols)
+    ]
+    if mismatches:
+        blocks.append(
+            {
+                "type": "shape_mismatch",
+                "message": (
+                    f"Grid dimensions must be {expected_rows}x{expected_cols}. "
+                    f"Mismatched: {', '.join(mismatches)}"
+                ),
+            }
+        )
+        return blocks
+
+    invalid_base_cells: list[dict[str, Any]] = []
+    for cylinder in ("front", "rear"):
+        for rpm_idx, row in enumerate(base_ve[cylinder]):
+            for map_idx, value in enumerate(row):
+                if not math.isfinite(value) or value <= 0:
+                    invalid_base_cells.append(
+                        {
+                            "rpm": _axis_value(rpm_axis, rpm_idx),
+                            "map": _axis_value(map_axis, map_idx),
+                            "value": float(value),
+                            "cylinder": cylinder,
+                        }
+                    )
+
+    if invalid_base_cells:
+        blocks.append(
+            {
+                "type": "invalid_base_ve",
+                "message": (
+                    f"Base VE contains {len(invalid_base_cells)} invalid cells "
+                    "(zero, negative, or NaN)."
+                ),
+                "cells": [
+                    {"rpm": c["rpm"], "map": c["map"], "value": c["value"]}
+                    for c in invalid_base_cells[:10]
+                ],
+            }
+        )
+
+    front_active_count = 0
+    rear_active_count = 0
+
+    for rpm_idx, row in enumerate(corrections["front"]):
+        for map_idx, correction in enumerate(row):
+            if has_active_correction(
+                correction,
+                hit_counts["front"][rpm_idx][map_idx],
+            ):
+                front_active_count += 1
+
+    for rpm_idx, row in enumerate(corrections["rear"]):
+        for map_idx, correction in enumerate(row):
+            if has_active_correction(
+                correction,
+                hit_counts["rear"][rpm_idx][map_idx],
+            ):
+                rear_active_count += 1
+
+    has_front = front_active_count > 0
+    has_rear = rear_active_count > 0
+    if has_front != has_rear:
+        blocks.append(
+            {
+                "type": "partial_cylinder",
+                "message": (
+                    f"Both cylinders required. Active cells: front={front_active_count}, "
+                    f"rear={rear_active_count}. Ensure data collection captures both cylinders."
+                ),
+            }
+        )
+
+    extreme_cells: list[dict[str, Any]] = []
+    for cylinder in ("front", "rear"):
+        for rpm_idx, row in enumerate(corrections[cylinder]):
+            for map_idx, correction in enumerate(row):
+                hits = hit_counts[cylinder][rpm_idx][map_idx]
+                if hits < SAFETY["min_hits_for_inclusion"]:
+                    continue
+                sanitized = sanitize_correction(correction)
+                raw_delta_pct = abs((sanitized - 1.0) * 100.0)
+                if raw_delta_pct > SAFETY["block_raw_delta_pct"]:
+                    extreme_cells.append(
+                        {
+                            "rpm": _axis_value(rpm_axis, rpm_idx),
+                            "map": _axis_value(map_axis, map_idx),
+                            "value": float(raw_delta_pct),
+                            "cylinder": cylinder,
+                        }
+                    )
+
+    if extreme_cells:
+        blocks.append(
+            {
+                "type": "extreme_correction",
+                "message": (
+                    f"{len(extreme_cells)} cells exceed ±{SAFETY['block_raw_delta_pct']:.0f}% "
+                    "correction. This usually indicates wrong base tune, sensor error, "
+                    "or hardware change."
+                ),
+                "cells": [
+                    {"rpm": c["rpm"], "map": c["map"], "value": c["value"]}
+                    for c in extreme_cells[:10]
+                ],
+            }
+        )
+
+    return blocks
+
+
+def get_block_reason_description(block_type: BlockReasonType) -> str:
+    """Human-readable summary for block reason type."""
+    descriptions = {
+        "extreme_correction": "Extreme corrections detected - check sensor data or base tune",
+        "missing_base": "No base VE table loaded - import a PVV file or select a preset",
+        "shape_mismatch": "Grid dimensions do not match - reload data",
+        "partial_cylinder": "Missing data for one cylinder - collect more samples",
+        "invalid_base_ve": "Base VE contains invalid values - check imported file",
+        "empty_grid": "Empty grid - import a valid tune file",
+    }
+    return descriptions.get(block_type, "Unknown validation error")

--- a/api/services/autotune/safety_gates.py
+++ b/api/services/autotune/safety_gates.py
@@ -28,7 +28,6 @@ SAFETY: SafetyThresholds = {
     "warn_coverage_pct": 50.0,
 }
 
-
 BlockReasonType = Literal[
     "extreme_correction",
     "missing_base",
@@ -140,9 +139,7 @@ def check_block_conditions(
         ("hitCounts.rear", hit_counts["rear"]),
     ]
     mismatches = [
-        name
-        for name, grid in grids
-        if _shape(grid) != (expected_rows, expected_cols)
+        name for name, grid in grids if _shape(grid) != (expected_rows, expected_cols)
     ]
     if mismatches:
         blocks.append(

--- a/api/services/autotune/safety_gates.py
+++ b/api/services/autotune/safety_gates.py
@@ -99,6 +99,7 @@ def _shape(grid: list[list[float]]) -> tuple[int, int]:
     return (len(grid), len(grid[0]) if grid[0] else 0)
 
 
+# skipcq: PY-R1000
 def check_block_conditions(
     base_ve: DualCylinderGrid | None,
     corrections: DualCylinderGrid,

--- a/api/services/autotune_workflow.py
+++ b/api/services/autotune_workflow.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -43,15 +43,11 @@ from api.services.yourdyno import parse_yourdyno_run
 # Import TuneLab-inspired filtering and binning modules
 from dynoai.core.signal_filters import (
     CompositeFilter,
-    FilteredSample,
     FilterStatistics,
     LowpassFilter,
-    MinMaxFilter,
     SignalFilter,
     StatisticalOutlierFilter,
     TimeAwareMinMaxFilter,
-    create_tunelab_filter_chain,
-    filter_afr_samples,
     samples_from_arrays,
     samples_to_arrays,
 )
@@ -62,13 +58,11 @@ from dynoai.core.ve_math import (
     calculate_ve_correction,
     correction_to_percentage,
 )
+from dynoai.core.kernel_sentinel import KernelSentinel, KernelSentinelConfig
 from dynoai.core.weighted_binning import (
     LogarithmicWeighting,
-    UniformWeighting,
     WeightedBinAccumulator,
     WeightingStrategy,
-    create_ve_accumulator,
-    generate_sample_table_tunelab_style,
 )
 
 logger = logging.getLogger(__name__)
@@ -231,6 +225,7 @@ class AutoTuneWorkflow:
         max_correction_pct: float = 10.0,
         afr_targets: Optional[dict[int, float]] = None,
         math_version: Optional[MathVersion] = None,
+        kernel_sentinel_config: Optional[dict[str, Any]] = None,
         # TuneLab-inspired filtering options
         enable_filtering: bool = False,
         lowpass_rc_ms: float = 500.0,
@@ -242,6 +237,8 @@ class AutoTuneWorkflow:
         # TuneLab-inspired weighting options
         use_weighted_binning: bool = False,
         weighting_strategy: Optional[WeightingStrategy] = None,
+        use_dual_bank_weighting: bool = False,
+        rear_bank_weight: float = 1.15,
     ) -> None:
         """
         Initialize AutoTuneWorkflow.
@@ -252,6 +249,7 @@ class AutoTuneWorkflow:
             max_correction_pct: Maximum correction percentage (±)
             afr_targets: Custom AFR targets by MAP (kPa -> AFR)
             math_version: VE calculation math version
+            kernel_sentinel_config: Optional per-session safety config
 
             # TuneLab-inspired filtering (NEW)
             enable_filtering: Enable AFR signal filtering before analysis
@@ -265,11 +263,16 @@ class AutoTuneWorkflow:
             # TuneLab-inspired weighting (NEW)
             use_weighted_binning: Use distance-weighted cell accumulation
             weighting_strategy: Custom weighting strategy (default: LogarithmicWeighting)
+            use_dual_bank_weighting: Blend front/rear AFR when both banks exist
+            rear_bank_weight: Relative weight for rear bank (default +15%)
         """
         self.rpm_axis = rpm_axis or self.DEFAULT_RPM_AXIS
         self.map_axis = map_axis or self.DEFAULT_MAP_AXIS
         self.max_correction_pct = max_correction_pct
         self.math_version = math_version or self.DEFAULT_MATH_VERSION
+        self.kernel_sentinel = KernelSentinel(
+            KernelSentinelConfig.from_dict(kernel_sentinel_config)
+        )
 
         # Allow custom AFR targets (keyed by MAP in kPa)
         if afr_targets:
@@ -289,6 +292,8 @@ class AutoTuneWorkflow:
         # TuneLab-inspired weighting configuration
         self.use_weighted_binning = use_weighted_binning
         self.weighting_strategy = weighting_strategy or LogarithmicWeighting()
+        self.use_dual_bank_weighting = use_dual_bank_weighting
+        self.rear_bank_weight = rear_bank_weight
 
         self.sessions: dict[str, AutoTuneSession] = {}
 
@@ -582,6 +587,21 @@ class AutoTuneWorkflow:
                 session.peak_tq_rpm = float(df.loc[peak_idx, rpm_col])
 
     @staticmethod
+    def _find_dual_bank_afr_columns(columns: list[str]) -> tuple[str | None, str | None]:
+        front_markers = ["afr1", "lc1", "front", "bank1", "left"]
+        rear_markers = ["afr2", "lc2", "rear", "bank2", "right"]
+        normalized = [(c, str(c).lower()) for c in columns if "afr" in str(c).lower()]
+
+        front = None
+        rear = None
+        for original, lower in normalized:
+            if front is None and any(m in lower for m in front_markers):
+                front = original
+            if rear is None and any(m in lower for m in rear_markers):
+                rear = original
+        return front, rear
+
+    @staticmethod
     def import_tune(session: AutoTuneSession, tune_path: str) -> bool:
         """
         Import a PVV tune file as the base tune.
@@ -643,6 +663,24 @@ class AutoTuneWorkflow:
             return None
 
         afr_meas_col = next((c for c in afr_cols if "Meas" in c), afr_cols[0])
+
+        if self.use_dual_bank_weighting:
+            front_col, rear_col = self._find_dual_bank_afr_columns(list(df.columns))
+            if front_col and rear_col:
+                df[front_col] = pd.to_numeric(df[front_col], errors="coerce")
+                df[rear_col] = pd.to_numeric(df[rear_col], errors="coerce")
+                total_weight = 1.0 + self.rear_bank_weight
+                df["AFR Meas Dual"] = (
+                    df[front_col] + (df[rear_col] * self.rear_bank_weight)
+                ) / total_weight
+                afr_meas_col = "AFR Meas Dual"
+                logger.info(
+                    "Using dual-bank AFR weighting (%s + %s*%.2f) / %.2f",
+                    front_col,
+                    rear_col,
+                    self.rear_bank_weight,
+                    total_weight,
+                )
 
         # Convert AFR to numeric
         df[afr_meas_col] = pd.to_numeric(df[afr_meas_col], errors="coerce")
@@ -719,12 +757,16 @@ class AutoTuneWorkflow:
                         mean_afr is not None
                         and hit_matrix[i, j] >= self.MIN_HITS_PER_ZONE
                     ):
+                        mean_afr_value = float(mean_afr)
                         target_afr = self.get_target_afr(self.map_axis[j])
-                        afr_error = mean_afr - target_afr
+                        afr_error = mean_afr_value - target_afr
                         afr_error_matrix[i, j] = afr_error
 
                         ve_correction = calculate_ve_correction(
-                            mean_afr, target_afr, version=self.math_version, clamp=False
+                            mean_afr_value,
+                            target_afr,
+                            version=self.math_version,
+                            clamp=False,
                         )
                         ve_delta_pct = correction_to_percentage(ve_correction)
                         ve_delta_matrix[i, j] = ve_delta_pct
@@ -856,8 +898,11 @@ class AutoTuneWorkflow:
         raw_corrections = 1 + ve_delta_matrix / 100
 
         # Apply safety clamps
-        min_mult = 1 - self.max_correction_pct / 100
-        max_mult = 1 + self.max_correction_pct / 100
+        effective_clamp_pct = self.kernel_sentinel.effective_max_correction_pct(
+            self.max_correction_pct
+        )
+        min_mult = 1 - effective_clamp_pct / 100
+        max_mult = 1 + effective_clamp_pct / 100
 
         clamped_corrections = np.clip(raw_corrections, min_mult, max_mult)
         clipped_count = int(
@@ -871,6 +916,17 @@ class AutoTuneWorkflow:
 
         # For zones without enough data, use 1.0 (no change)
         correction_matrix[~valid_mask] = 1.0
+
+        lean_streak_breach = self.kernel_sentinel.evaluate_lean_streak_from_grid(
+            ve_delta_matrix,
+            valid_mask,
+            afr_error_tolerance=self.AFR_ERROR_TOLERANCE,
+        )
+        if lean_streak_breach is not None:
+            session.errors.append(lean_streak_breach.message)
+            if lean_streak_breach.halt:
+                session.status = "halted_on_sentinel"
+                return None
 
         result = VECorrectionResult(
             correction_table=correction_matrix,

--- a/api/services/autotune_workflow.py
+++ b/api/services/autotune_workflow.py
@@ -39,6 +39,7 @@ from api.services.powercore_integration import (
     powervision_log_to_dynoai_format,
 )
 from api.services.yourdyno import parse_yourdyno_run
+from dynoai.core.kernel_sentinel import KernelSentinel, KernelSentinelConfig
 
 # Import TuneLab-inspired filtering and binning modules
 from dynoai.core.signal_filters import (
@@ -58,7 +59,6 @@ from dynoai.core.ve_math import (
     calculate_ve_correction,
     correction_to_percentage,
 )
-from dynoai.core.kernel_sentinel import KernelSentinel, KernelSentinelConfig
 from dynoai.core.weighted_binning import (
     LogarithmicWeighting,
     WeightedBinAccumulator,
@@ -587,7 +587,9 @@ class AutoTuneWorkflow:
                 session.peak_tq_rpm = float(df.loc[peak_idx, rpm_col])
 
     @staticmethod
-    def _find_dual_bank_afr_columns(columns: list[str]) -> tuple[str | None, str | None]:
+    def _find_dual_bank_afr_columns(
+        columns: list[str],
+    ) -> tuple[str | None, str | None]:
         front_markers = ["afr1", "lc1", "front", "bank1", "left"]
         rear_markers = ["afr2", "lc2", "rear", "bank2", "right"]
         normalized = [(c, str(c).lower()) for c in columns if "afr" in str(c).lower()]

--- a/api/services/autotune_workflow.py
+++ b/api/services/autotune_workflow.py
@@ -618,6 +618,7 @@ class AutoTuneWorkflow:
             session.errors.append(f"Tune import failed: {e}")
             return False
 
+    # skipcq: PY-R1000
     def analyze_afr(self, session: AutoTuneSession) -> Optional[AFRAnalysisResult]:
         """
         Analyze AFR error across RPM/MAP zones using 2D grid.

--- a/api/services/integrations/powercore/README.md
+++ b/api/services/integrations/powercore/README.md
@@ -9,6 +9,8 @@ DynoAI synthetic WinPEP generator directly from inside **Dynojet Power Core**.
 | --- | --- |
 | `dynoai_tunelab_bridge.py` | WinForms-based TuneLab script. Auto-detects peak RPM from the most recently loaded log, then shells out to `python -m tools.synthetic.winpep8_cli` inside your DynoAI repo. |
 | `dynoai_preflight.py` | TuneLab pre-flight safety checker (battery/AFR/engine temp/intake temp) before a dyno pull. |
+| `dynoai_autotune.py` | TuneLab per-cylinder autotune script. Exports loaded log channels to temp CSV, runs `python -m tools.autotune.tunelab_entrypoint preview`, and supports both Export and F1.1 live-tune apply in dual-cylinder mode. |
+| `inspect_tunelab_context.py` | Throwaway TuneLab probe script that dumps `dir(context)` and tests candidate VE table names so you can confirm table API behavior in a specific Power Core build. |
 
 ## Installation Steps
 
@@ -32,6 +34,7 @@ DynoAI synthetic WinPEP generator directly from inside **Dynojet Power Core**.
 4. **Configure DynoAI environment**  
    Ensure your DynoAI repo (`DEFAULT_REPO_ROOT`) is accessible and that running
    the CLI manually works:
+
    ```powershell
    cd C:\Dev\DynoAI_3
    python -m tools.synthetic.winpep8_cli --help
@@ -58,15 +61,102 @@ Use `dynoai_preflight.py` exactly like the bridge script:
 3. Click **Perform Correction** to run the check on the most recently loaded log
 
 The script evaluates:
+
 - Battery voltage (`B+`/aliases)
 - AFR front and rear channels (`WBO2 F` / `WBO2 R` + aliases)
 - Engine temp (`ET`/aliases)
 - Intake temp (`IAT`/aliases)
 
 Output is a single verdict dialog:
+
 - **READY FOR PULL**
 - **READY with warnings - proceed with caution**
 - **NOT READY - do not pull**
+
+## DynoAI Autotune (Preview + Apply)
+
+`dynoai_autotune.py` now provides:
+
+- F1 preview export (`VE_Front_Correction_2D.csv`, `VE_Rear_Correction_2D.csv`, `correction_summary.json`)
+- F1.1 dual-cylinder apply (`context.PutTable`) via server-side `VEApply` + `SessionLogger`
+
+### Install
+
+1. Power Core → Tools → TuneLab → Manage Scripts → *Add*
+2. Select `api/services/integrations/powercore/dynoai_autotune.py`
+3. Ensure your DynoAI repo root and Python path in script defaults are valid:
+   - `DEFAULT_REPO_ROOT`
+   - `DEFAULT_PYTHON`
+
+The script shells to:
+
+```powershell
+python -m tools.autotune.tunelab_entrypoint preview --help
+python -m tools.autotune.tunelab_entrypoint apply --help
+```
+
+### Autotune Preview Usage
+
+1. Load a log in Data Center that includes both front and rear wideband channels.
+2. Run the `DynoAIAutotune` script.
+3. Review the preview dialog:
+   - Front (VE F) summary metrics
+   - Rear (VE R) summary metrics
+   - Safety-aware banner and block reasons from `summary["safety"]`
+4. Click **Export Only** to copy outputs into `runs/<run_id>/corrections/`:
+   - `VE_Front_Correction_2D.csv`
+   - `VE_Rear_Correction_2D.csv`
+   - `correction_summary.json`
+   - optional `.pvv` patch when emitted by CLI flag
+
+### F1.1 Apply Flow
+
+When the loaded log is dual-cylinder and `summary["safety"]["apply_blocked"]` is false:
+
+1. Click **Apply to Loaded Tune**
+2. Confirm backup prompt (manual Power Core Save As recommended)
+3. Script exports current loaded VE front/rear tables to temp CSV
+4. Script calls:
+   - `python -m tools.autotune.tunelab_entrypoint apply --run-id ... --output-dir ... --base-front ... --base-rear ...`
+5. CLI runs `VEApply(max_adjust_pct=15.0)` and records events using `SessionLogger`
+6. Script reads `VE_Front_Applied.csv` / `VE_Rear_Applied.csv`, writes tables via `context.PutTable(...)`
+7. Artifacts land in:
+   - `runs/<run_id>/session_log.json`
+   - `runs/<run_id>/snapshots/`
+   - `logs/autotune_applied.log`
+   - `runs/<run_id>/corrections/` (export copies)
+
+### Button State Matrix
+
+- **Dual-cylinder + not blocked:** Apply button visible and enabled
+- **Dual-cylinder + blocked:** Apply visible but disabled; reason messages shown
+- **Single-cylinder mode:** Apply hidden (export-only by design)
+
+### Table Name Overrides
+
+Tune names vary between Power Core builds. Edit these constants in `dynoai_autotune.py` if needed:
+
+- `VE_FRONT_TABLE_NAME`
+- `VE_REAR_TABLE_NAME`
+
+Use `inspect_tunelab_context.py` in TuneLab to probe the active API/table names before changing constants.
+
+### Known limits
+
+- Uses static MAP-indexed AFR target curve (`static_map_curve_v1`) in F1.
+- `from_tune.AFR_Target` is reserved for F1.1 and not enabled in this release.
+- Temp working files are cleaned up after the run; only exported files are persisted.
+
+### Single-wideband logs
+
+- If the loaded log only has one wideband channel populated (front or rear),
+  the TuneLab script auto-enables **single-cylinder mode** and passes
+  `--single-cylinder front` or `--single-cylinder rear` to the CLI.
+- Preview dialog shows the populated cylinder's metrics and marks the other
+  side as "Not computed." with an orange banner making the mode explicit.
+- The summary JSON carries `"mode": "single_cylinder_front" | "single_cylinder_rear"`
+  and the missing side as `null`. No CSV is emitted for the missing side.
+- Apply is safety-blocked in single mode via `BlockReason.type == "partial_cylinder"`.
 
 ## Watch-folder auto-import (F4)
 
@@ -77,10 +167,12 @@ Power Core folders and streams ingest events over SSE.
 
 1. Install both dependency sets so `watchdog` is present regardless of your
    startup flow:
+
    ```powershell
    pip install -r requirements.txt
    pip install -r api\requirements.txt
    ```
+
 2. (Optional) Add machine-specific folders:
    - Copy `config/watch_folder.example.yaml` to `config/watch_folder.yaml`
    - Add extra folders under `folders:`
@@ -97,6 +189,7 @@ Power Core folders and streams ingest events over SSE.
 - `POST /api/powercore/watch/rescan` - bounded rescan for one configured folder
 
 Example rescan body:
+
 ```json
 {
   "folder": "C:\\Users\\dawso\\OneDrive\\Documents\\PowerCoreBackups",

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -35,8 +35,10 @@ clr.AddReference("System.Drawing")
 
 # json: prefer stdlib, fall back to None on stripped IronPython distributions.
 # Single-line guarded form so isort/black/yapf cannot split a `try:` block.
-try: import json as _py_json  # noqa: E701,E401
-except Exception: _py_json = None  # noqa: E701,E722
+try:
+    import json as _py_json  # noqa: E701,E401
+except Exception:
+    _py_json = None  # noqa: E701,E722
 
 # CLR namespaces -- IronPython 2.7 sometimes exposes these without the System.
 # prefix on legacy Power Core builds, so each block is its own try/except.
@@ -77,20 +79,11 @@ try:
     )
 except Exception:
     from Windows.Forms import (  # type: ignore[no-redef]
-        Button,
-        DialogResult,
-        Form,
-        FormBorderStyle,
-        FormStartPosition,
-        GroupBox,
-        Label,
-        MessageBox,
-        MessageBoxButtons,
-        MessageBoxIcon,
+        Button, DialogResult, Form, FormBorderStyle, FormStartPosition,
+        GroupBox, Label, MessageBox, MessageBoxButtons, MessageBoxIcon,
     )
 
 from tunelab import ConfigurableChannelProvider
-
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -116,7 +109,6 @@ MODE_SINGLE_FRONT = "single_cylinder_front"
 MODE_SINGLE_REAR = "single_cylinder_rear"
 MODE_CHOICES = (MODE_DUAL, MODE_SINGLE_FRONT, MODE_SINGLE_REAR)
 
-
 _RUN_SLUG_INVALID_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
@@ -139,6 +131,7 @@ def _safe_run_slug(run_id):
     if not slug or slug in (".", ".."):
         return "run"
     return slug
+
 
 VE_FRONT_TABLE_CANDIDATES = [
     VE_FRONT_TABLE_NAME,
@@ -305,44 +298,37 @@ TPS_ALIASES = [
 ]
 
 # Broad probe list for diagnostics when strict aliases fail.
-DIAG_PROBE_NAMES = (
-    RPM_CHANNEL_ALIASES
-    + MAP_CHANNEL_ALIASES
-    + AFR_F_ALIASES
-    + AFR_R_ALIASES
-    + AFR_F_VOLT_ALIASES
-    + AFR_R_VOLT_ALIASES
-    + TPS_ALIASES
-    + [
-        "B+",
-        "VBatt",
-        "Battery",
-        "Battery Voltage",
-        "ET",
-        "Engine Temp",
-        "ECT",
-        "Coolant Temp",
-        "Engine Temperature",
-        "IAT",
-        "Intake Air Temp",
-        "Intake Temperature",
-        "Vehicle Speed",
-        "Gear",
-        "Spark Advance",
-        "Ignition Timing",
-        "Injector Duty",
-        "Injector Pulse Width",
-        "Fuel Pressure",
-        "Oil Pressure",
-        "Oil Temp",
-        "Knock",
-        "Knock Retard",
-        "Horsepower",
-        "HP",
-        "Torque",
-        "TQ",
-    ]
-)
+DIAG_PROBE_NAMES = (RPM_CHANNEL_ALIASES + MAP_CHANNEL_ALIASES + AFR_F_ALIASES +
+                    AFR_R_ALIASES + AFR_F_VOLT_ALIASES + AFR_R_VOLT_ALIASES +
+                    TPS_ALIASES + [
+                        "B+",
+                        "VBatt",
+                        "Battery",
+                        "Battery Voltage",
+                        "ET",
+                        "Engine Temp",
+                        "ECT",
+                        "Coolant Temp",
+                        "Engine Temperature",
+                        "IAT",
+                        "Intake Air Temp",
+                        "Intake Temperature",
+                        "Vehicle Speed",
+                        "Gear",
+                        "Spark Advance",
+                        "Ignition Timing",
+                        "Injector Duty",
+                        "Injector Pulse Width",
+                        "Fuel Pressure",
+                        "Oil Pressure",
+                        "Oil Temp",
+                        "Knock",
+                        "Knock Retard",
+                        "Horsepower",
+                        "HP",
+                        "Torque",
+                        "TQ",
+                    ])
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -482,7 +468,8 @@ def _list_channel_names(file_handle):
             continue
         try:
             for item in result:
-                name_attr = getattr(item, "Name", None) or getattr(item, "name", None)
+                name_attr = getattr(item, "Name", None) or getattr(
+                    item, "name", None)
                 if name_attr is not None:
                     _add(name_attr)
                 else:
@@ -546,9 +533,8 @@ def _value_at_or_before(samples, target_ms, idx_hint):
 
 
 def _create_temp_dir():
-    temp_dir = Path.Combine(
-        Path.GetTempPath(), "dynoai_autotune_" + Guid.NewGuid().ToString("N")
-    )
+    temp_dir = Path.Combine(Path.GetTempPath(),
+                            "dynoai_autotune_" + Guid.NewGuid().ToString("N"))
     Directory.CreateDirectory(temp_dir)
     return temp_dir
 
@@ -614,9 +600,10 @@ def _estimate_map_from_rpm(rpm_value):
     return 80.0
 
 
-def _resolve_afr_or_voltage(
-    file_handle, afr_aliases, volt_aliases, lambda_aliases=None
-):
+def _resolve_afr_or_voltage(file_handle,
+                            afr_aliases,
+                            volt_aliases,
+                            lambda_aliases=None):
     """Resolve AFR input: prefer AFR-unit, fall back to voltage, then Lambda.
 
     Returns (channel, column_name). ``column_name`` is:
@@ -660,11 +647,11 @@ def _resolve_channels(file_handle):
     rpm_ch = _try_channel(file_handle, RPM_CHANNEL_ALIASES)
     map_ch = _try_channel(file_handle, MAP_CHANNEL_ALIASES)
     afr_f_ch, front_volt_name = _resolve_afr_or_voltage(
-        file_handle, AFR_F_ALIASES, AFR_F_VOLT_ALIASES, AFR_F_LAMBDA_ALIASES
-    )
-    afr_r_ch, rear_volt_name = _resolve_afr_or_voltage(
-        file_handle, AFR_R_ALIASES, AFR_R_VOLT_ALIASES, AFR_R_LAMBDA_ALIASES
-    )
+        file_handle, AFR_F_ALIASES, AFR_F_VOLT_ALIASES, AFR_F_LAMBDA_ALIASES)
+    afr_r_ch, rear_volt_name = _resolve_afr_or_voltage(file_handle,
+                                                       AFR_R_ALIASES,
+                                                       AFR_R_VOLT_ALIASES,
+                                                       AFR_R_LAMBDA_ALIASES)
     tps_ch = _try_channel(file_handle, TPS_ALIASES)
     return {
         "rpm_ch": rpm_ch,
@@ -703,26 +690,24 @@ def _raise_channel_error(file_handle, missing, found_afr_f, found_afr_r):
     extra = nl.join(extra_lines)
 
     if ("AFR Front" in missing) or ("AFR Rear" in missing):
-        raise RuntimeError(
-            "Cannot find any AFR channel in the loaded log."
-            + nl
-            + "Missing: "
-            + ", ".join(missing)
-            + extra
-        )
-    raise RuntimeError("Missing required channels: " + ", ".join(missing) + extra)
+        raise RuntimeError("Cannot find any AFR channel in the loaded log." +
+                           nl + "Missing: " + ", ".join(missing) + extra)
+    raise RuntimeError("Missing required channels: " + ", ".join(missing) +
+                       extra)
 
 
 def _channel_score(file_handle):
     score = 0
     rpm_ch = _try_channel(file_handle, RPM_CHANNEL_ALIASES)
     map_ch = _try_channel(file_handle, MAP_CHANNEL_ALIASES)
-    afr_f_ch, front_raw_name = _resolve_afr_or_voltage(
-        file_handle, AFR_F_ALIASES, AFR_F_VOLT_ALIASES, AFR_F_LAMBDA_ALIASES
-    )
-    afr_r_ch, rear_raw_name = _resolve_afr_or_voltage(
-        file_handle, AFR_R_ALIASES, AFR_R_VOLT_ALIASES, AFR_R_LAMBDA_ALIASES
-    )
+    afr_f_ch, front_raw_name = _resolve_afr_or_voltage(file_handle,
+                                                       AFR_F_ALIASES,
+                                                       AFR_F_VOLT_ALIASES,
+                                                       AFR_F_LAMBDA_ALIASES)
+    afr_r_ch, rear_raw_name = _resolve_afr_or_voltage(file_handle,
+                                                      AFR_R_ALIASES,
+                                                      AFR_R_VOLT_ALIASES,
+                                                      AFR_R_LAMBDA_ALIASES)
     if rpm_ch is not None:
         score += 1
     if map_ch is not None:
@@ -772,9 +757,8 @@ def _export_loaded_log_csv(file_handle, csv_path):
         missing.append("AFR Front")
         missing.append("AFR Rear")
     if missing:
-        _raise_channel_error(
-            file_handle, missing, afr_f_ch is not None, afr_r_ch is not None
-        )
+        _raise_channel_error(file_handle, missing, afr_f_ch is not None,
+                             afr_r_ch is not None)
 
     rpm_samples = _read_samples(rpm_ch)
     map_samples = _read_samples(map_ch)
@@ -831,7 +815,8 @@ def _export_loaded_log_csv(file_handle, csv_path):
 
         for t_ms, rpm_value in rpm_samples:
             if map_samples:
-                map_value, map_idx = _value_at_or_before(map_samples, t_ms, map_idx)
+                map_value, map_idx = _value_at_or_before(
+                    map_samples, t_ms, map_idx)
             else:
                 map_value = _estimate_map_from_rpm(rpm_value)
             if map_value is None:
@@ -845,27 +830,28 @@ def _export_loaded_log_csv(file_handle, csv_path):
 
             if front_has_data:
                 afr_f_value, afr_f_idx = _value_at_or_before(
-                    afr_f_samples, t_ms, afr_f_idx
-                )
+                    afr_f_samples, t_ms, afr_f_idx)
                 if afr_f_value is None:
                     continue
                 row_values.append("%.3f" % afr_f_value)
             if rear_has_data:
                 afr_r_value, afr_r_idx = _value_at_or_before(
-                    afr_r_samples, t_ms, afr_r_idx
-                )
+                    afr_r_samples, t_ms, afr_r_idx)
                 if afr_r_value is None:
                     continue
                 row_values.append("%.3f" % afr_r_value)
             if tps_samples:
-                tps_value, tps_idx = _value_at_or_before(tps_samples, t_ms, tps_idx)
-                row_values.append("" if tps_value is None else ("%.3f" % tps_value))
+                tps_value, tps_idx = _value_at_or_before(
+                    tps_samples, t_ms, tps_idx)
+                row_values.append("" if tps_value is None else ("%.3f" %
+                                                                tps_value))
 
             handle.write(",".join([str(v) for v in row_values]) + "\n")
             row_count += 1
 
     if row_count == 0:
-        raise RuntimeError("No aligned rows could be exported from loaded channels.")
+        raise RuntimeError(
+            "No aligned rows could be exported from loaded channels.")
 
     return row_count, mode
 
@@ -943,7 +929,8 @@ def _load_summary(summary_path):
         raw_value = serializer.DeserializeObject(raw_text)
         return _dotnet_to_python(raw_value)
     except Exception as exc:
-        raise RuntimeError("Unable to parse correction_summary.json: %s" % str(exc))
+        raise RuntimeError("Unable to parse correction_summary.json: %s" %
+                           str(exc))
 
 
 def _to_metric(value, decimals):
@@ -1053,7 +1040,8 @@ def _write_ve_csv(csv_path, rpm_axis, map_axis, grid):
         handle.write((",".join(header) + "\n"))
         for rpm, row in zip(rpm_axis, grid):
             values = ["%.6f" % float(v) for v in row]
-            handle.write((_format_axis_value(rpm) + "," + ",".join(values) + "\n"))
+            handle.write(
+                (_format_axis_value(rpm) + "," + ",".join(values) + "\n"))
 
 
 def _table_get_value(table_obj, row_idx, col_idx):
@@ -1071,9 +1059,8 @@ def _table_get_value(table_obj, row_idx, col_idx):
     try:
         return float(table_obj[row_idx][col_idx])
     except Exception as exc:
-        raise RuntimeError(
-            "Unable to read table cell (%d,%d): %s" % (row_idx, col_idx, str(exc))
-        )
+        raise RuntimeError("Unable to read table cell (%d,%d): %s" %
+                           (row_idx, col_idx, str(exc)))
 
 
 def _table_set_value(table_obj, row_idx, col_idx, value):
@@ -1097,9 +1084,8 @@ def _table_set_value(table_obj, row_idx, col_idx, value):
         table_obj[row_idx][col_idx] = value
         return
     except Exception as exc:
-        raise RuntimeError(
-            "Unable to write table cell (%d,%d): %s" % (row_idx, col_idx, str(exc))
-        )
+        raise RuntimeError("Unable to write table cell (%d,%d): %s" %
+                           (row_idx, col_idx, str(exc)))
 
 
 def _extract_table_grid(table_obj, rows, cols):
@@ -1111,8 +1097,8 @@ def _extract_table_grid(table_obj, rows, cols):
                 row = []
                 for c in range(cols):
                     row.append(
-                        _table_get_value(table_obj, r + base_index, c + base_index)
-                    )
+                        _table_get_value(table_obj, r + base_index,
+                                         c + base_index))
                 grid.append(row)
             return grid, base_index
         except Exception as exc:
@@ -1124,7 +1110,8 @@ def _extract_table_grid(table_obj, rows, cols):
 def _apply_grid_to_table(table_obj, grid, base_index):
     for r, row in enumerate(grid):
         for c, value in enumerate(row):
-            _table_set_value(table_obj, r + base_index, c + base_index, float(value))
+            _table_set_value(table_obj, r + base_index, c + base_index,
+                             float(value))
 
 
 def _context_probe_lines():
@@ -1146,16 +1133,15 @@ def _resolve_table_from_candidates(candidates, expected_rows, expected_cols):
             if table_obj is None:
                 attempts.append("%s: returned None" % name)
                 continue
-            _, base_index = _extract_table_grid(table_obj, expected_rows, expected_cols)
+            _, base_index = _extract_table_grid(table_obj, expected_rows,
+                                                expected_cols)
             return table_obj, name, base_index
         except Exception as exc:
             attempts.append("%s: %s" % (name, str(exc)))
     detail = "\r\n".join(attempts) if attempts else "No candidates attempted."
-    raise RuntimeError(
-        "Could not resolve VE table from candidates.\r\n"
-        "Candidates: %s\r\n%s\r\ncontext: %s"
-        % (", ".join(candidates), detail, _context_probe_lines())
-    )
+    raise RuntimeError("Could not resolve VE table from candidates.\r\n"
+                       "Candidates: %s\r\n%s\r\ncontext: %s" %
+                       (", ".join(candidates), detail, _context_probe_lines()))
 
 
 def _extract_apply_paths(stdout):
@@ -1171,13 +1157,13 @@ def _extract_apply_paths(stdout):
     return None
 
 
-def _append_apply_audit_log(
-    summary, file_desc, front_table_name, rear_table_name, session_log_path
-):
+def _append_apply_audit_log(summary, file_desc, front_table_name,
+                            rear_table_name, session_log_path):
     logs_dir = Path.Combine(DEFAULT_REPO_ROOT, "logs")
     Directory.CreateDirectory(logs_dir)
     audit_path = Path.Combine(logs_dir, "autotune_applied.log")
-    backup_path = Path.Combine(Path.GetDirectoryName(session_log_path), "snapshots")
+    backup_path = Path.Combine(Path.GetDirectoryName(session_log_path),
+                               "snapshots")
     record = {
         "ts": DateTime.UtcNow.ToString("o"),
         "run_id": _safe_get(summary, "run_id", ""),
@@ -1209,6 +1195,7 @@ def _axes_match(expected_axis, actual_axis, epsilon=1e-6):
 
 
 class PreviewDialog(Form):
+
     def __init__(self, summary, preview_dir):
         self.summary = summary
         self.preview_dir = preview_dir
@@ -1230,8 +1217,7 @@ class PreviewDialog(Form):
         safety = _safe_get(self.summary, "safety", {}) or {}
         apply_blocked = bool(_safe_get(safety, "apply_blocked", False))
         warn_threshold = float(
-            _safe_get(safety, "warn_threshold_pct", WARN_THRESHOLD_PCT)
-        )
+            _safe_get(safety, "warn_threshold_pct", WARN_THRESHOLD_PCT))
         over_warn = bool(_safe_get(self.summary, "over_warn_threshold"))
         if apply_blocked and mode == MODE_DUAL:
             banner.Text = "APPLY BLOCKED: safety gates must pass before write-back."
@@ -1239,20 +1225,17 @@ class PreviewDialog(Form):
         elif over_warn:
             banner.Text = (
                 "WARNING: max correction exceeds %.0f%%. Review before any apply."
-                % warn_threshold
-            )
+                % warn_threshold)
             banner.ForeColor = Color.DarkOrange
         elif mode == "single_cylinder_front":
             banner.Text = (
                 "Single-wideband log (front). Only front correction will be exported. "
-                "Rear is unchanged."
-            )
+                "Rear is unchanged.")
             banner.ForeColor = Color.DarkOrange
         elif mode == "single_cylinder_rear":
             banner.Text = (
                 "Single-wideband log (rear). Only rear correction will be exported. "
-                "Front is unchanged."
-            )
+                "Front is unchanged.")
             banner.ForeColor = Color.DarkOrange
         else:
             banner.Text = "Preview only. Review outputs before any manual flash."
@@ -1260,11 +1243,9 @@ class PreviewDialog(Form):
         self.Controls.Add(banner)
 
         front_group = self._build_cylinder_group(
-            "Front (VE F)", _safe_get(self.summary, "front"), 15
-        )
+            "Front (VE F)", _safe_get(self.summary, "front"), 15)
         rear_group = self._build_cylinder_group(
-            "Rear (VE R)", _safe_get(self.summary, "rear"), 285
-        )
+            "Rear (VE R)", _safe_get(self.summary, "rear"), 285)
         self.Controls.Add(front_group)
         self.Controls.Add(rear_group)
 
@@ -1300,9 +1281,8 @@ class PreviewDialog(Form):
                 reason_label.Location = Point(15, 340)
                 reason_label.Size = Size(520, 20)
                 reason_label.ForeColor = Color.Red
-                reason_label.Text = "Blocked: %s" % (
-                    "; ".join(messages) if messages else "Unknown safety reason."
-                )
+                reason_label.Text = "Blocked: %s" % ("; ".join(
+                    messages) if messages else "Unknown safety reason.")
                 self.Controls.Add(reason_label)
 
         btn_export = Button()
@@ -1339,18 +1319,15 @@ class PreviewDialog(Form):
             na_label = Label()
             na_label.Location = Point(10, 30)
             na_label.Size = Size(235, 60)
-            na_label.Text = (
-                "Not computed.\n"
-                "This cylinder had no wideband samples\n"
-                "in the loaded log."
-            )
+            na_label.Text = ("Not computed.\n"
+                             "This cylinder had no wideband samples\n"
+                             "in the loaded log.")
             na_label.ForeColor = Color.Gray
             group.Controls.Add(na_label)
             return group
 
-        self._add_metric(
-            group, "zones_adjusted", _safe_get(section, "zones_adjusted"), 30
-        )
+        self._add_metric(group, "zones_adjusted",
+                         _safe_get(section, "zones_adjusted"), 30)
         self._add_metric(
             group,
             "max_correction_pct",
@@ -1363,9 +1340,8 @@ class PreviewDialog(Form):
             _to_metric(_safe_get(section, "min_pct", 0.0), 2),
             90,
         )
-        self._add_metric(
-            group, "clipped_zones", _safe_get(section, "clipped_zones"), 120
-        )
+        self._add_metric(group, "clipped_zones",
+                         _safe_get(section, "clipped_zones"), 120)
         self._add_metric(
             group,
             "mean_afr_error",
@@ -1422,17 +1398,22 @@ def show_preview(summary, preview_dir):
 
 
 def _copy_export_outputs(summary, summary_path, extra_files=None):
-    run_id = str(_safe_get(summary, "run_id") or "").replace("\\", "/").strip("/")
+    run_id = str(_safe_get(summary, "run_id") or "").replace("\\",
+                                                             "/").strip("/")
     if not run_id:
-        raise RuntimeError("Summary missing run_id; cannot resolve export destination.")
+        raise RuntimeError(
+            "Summary missing run_id; cannot resolve export destination.")
 
     # Sanitize each path segment so a hostile or accidentally-malformed
     # run_id (".." or absolute paths) cannot escape DEFAULT_REPO_ROOT/runs.
     raw_parts = [part for part in run_id.split("/") if part.strip()]
     safe_parts = [_safe_run_slug(part) for part in raw_parts]
-    safe_parts = [part for part in safe_parts if part and part not in (".", "..")]
+    safe_parts = [
+        part for part in safe_parts if part and part not in (".", "..")
+    ]
     if not safe_parts:
-        raise RuntimeError("Summary run_id resolves to empty segments after sanitization.")
+        raise RuntimeError(
+            "Summary run_id resolves to empty segments after sanitization.")
 
     dest_dir = Path.Combine(DEFAULT_REPO_ROOT, "runs")
     for part in safe_parts:
@@ -1552,12 +1533,13 @@ def _show_cli_error(exit_code, stdout, stderr):
 
 
 class DynoAIAutotune(ConfigurableChannelProvider):
+
     def _perform_apply(self, summary, summary_path, temp_dir, file_handle):
         mode = str(_safe_get(summary, "mode", MODE_DUAL))
         if mode != MODE_DUAL:
             raise RuntimeError(
-                "Apply is only supported in dual-cylinder mode. Current mode: %s" % mode
-            )
+                "Apply is only supported in dual-cylinder mode. Current mode: %s"
+                % mode)
 
         confirm = MessageBox.Show(
             "Apply dual-cylinder corrections to the loaded tune?\r\n\r\n"
@@ -1579,18 +1561,14 @@ class DynoAIAutotune(ConfigurableChannelProvider):
         expected_rows = len(rpm_axis)
         expected_cols = len(map_axis)
         front_table, front_table_name, _ = _resolve_table_from_candidates(
-            VE_FRONT_TABLE_CANDIDATES, expected_rows, expected_cols
-        )
+            VE_FRONT_TABLE_CANDIDATES, expected_rows, expected_cols)
         rear_table, rear_table_name, _ = _resolve_table_from_candidates(
-            VE_REAR_TABLE_CANDIDATES, expected_rows, expected_cols
-        )
+            VE_REAR_TABLE_CANDIDATES, expected_rows, expected_cols)
 
         front_grid, front_index_base = _extract_table_grid(
-            front_table, expected_rows, expected_cols
-        )
+            front_table, expected_rows, expected_cols)
         rear_grid, rear_index_base = _extract_table_grid(
-            rear_table, expected_rows, expected_cols
-        )
+            rear_table, expected_rows, expected_cols)
 
         front_base_csv = Path.Combine(temp_dir, "VE_Front_Base.csv")
         rear_base_csv = Path.Combine(temp_dir, "VE_Rear_Base.csv")
@@ -1614,7 +1592,8 @@ class DynoAIAutotune(ConfigurableChannelProvider):
             "--max-adjust-pct",
             str(APPLY_MAX_ADJUST_PCT),
         ]
-        rc, stdout, stderr = run_cli(apply_args, timeout_seconds=APPLY_TIMEOUT_SECONDS)
+        rc, stdout, stderr = run_cli(apply_args,
+                                     timeout_seconds=APPLY_TIMEOUT_SECONDS)
         if rc != 0:
             _show_cli_error(rc, stdout, stderr)
             return None
@@ -1622,39 +1601,32 @@ class DynoAIAutotune(ConfigurableChannelProvider):
         parsed_paths = _extract_apply_paths(stdout)
         if not parsed_paths:
             raise RuntimeError(
-                "Apply CLI output parse failed.\r\nstdout:\r\n%s" % stdout
-            )
+                "Apply CLI output parse failed.\r\nstdout:\r\n%s" % stdout)
         apply_front_csv, apply_rear_csv, session_log_path = parsed_paths
         if not File.Exists(apply_front_csv) or not File.Exists(apply_rear_csv):
             raise RuntimeError(
                 "Apply CLI succeeded but expected applied CSVs are missing.\r\n"
-                "front=%s\r\nrear=%s" % (apply_front_csv, apply_rear_csv)
-            )
+                "front=%s\r\nrear=%s" % (apply_front_csv, apply_rear_csv))
 
-        front_rpm, front_map, front_applied_grid = _parse_ve_csv(apply_front_csv)
+        front_rpm, front_map, front_applied_grid = _parse_ve_csv(
+            apply_front_csv)
         rear_rpm, rear_map, rear_applied_grid = _parse_ve_csv(apply_rear_csv)
-        if (
-            not _axes_match(rpm_axis, front_rpm)
-            or not _axes_match(map_axis, front_map)
-            or not _axes_match(rpm_axis, rear_rpm)
-            or not _axes_match(map_axis, rear_map)
-        ):
+        if (not _axes_match(rpm_axis, front_rpm)
+                or not _axes_match(map_axis, front_map)
+                or not _axes_match(rpm_axis, rear_rpm)
+                or not _axes_match(map_axis, rear_map)):
             raise RuntimeError(
                 "Applied CSV axes do not match preview grid. "
-                "Check table shape compatibility before retrying."
-            )
-        if (
-            len(front_applied_grid) != expected_rows
-            or len(rear_applied_grid) != expected_rows
-        ):
-            raise RuntimeError("Applied CSV row count mismatch with preview grid.")
-        if (
-            front_applied_grid
-            and len(front_applied_grid[0]) != expected_cols
-            or rear_applied_grid
-            and len(rear_applied_grid[0]) != expected_cols
-        ):
-            raise RuntimeError("Applied CSV column count mismatch with preview grid.")
+                "Check table shape compatibility before retrying.")
+        if (len(front_applied_grid) != expected_rows
+                or len(rear_applied_grid) != expected_rows):
+            raise RuntimeError(
+                "Applied CSV row count mismatch with preview grid.")
+        if (front_applied_grid and len(front_applied_grid[0]) != expected_cols
+                or rear_applied_grid
+                and len(rear_applied_grid[0]) != expected_cols):
+            raise RuntimeError(
+                "Applied CSV column count mismatch with preview grid.")
 
         _apply_grid_to_table(front_table, front_applied_grid, front_index_base)
         _apply_grid_to_table(rear_table, rear_applied_grid, rear_index_base)
@@ -1680,8 +1652,7 @@ class DynoAIAutotune(ConfigurableChannelProvider):
             "session_log: %s\r\n"
             "audit_log: %s\r\n"
             "exports: %s\r\n\r\n"
-            "Review and flash using Power Core's native File menu."
-            % (
+            "Review and flash using Power Core's native File menu." % (
                 front_table_name,
                 rear_table_name,
                 session_log_path,
@@ -1734,7 +1705,8 @@ class DynoAIAutotune(ConfigurableChannelProvider):
             run_id = _build_run_id(file_handle)
             temp_dir = _create_temp_dir()
             input_csv = Path.Combine(temp_dir, "tunelab_input.csv")
-            _row_count, detected_mode = _export_loaded_log_csv(file_handle, input_csv)
+            _row_count, detected_mode = _export_loaded_log_csv(
+                file_handle, input_csv)
 
             args = [
                 "-m",
@@ -1752,7 +1724,8 @@ class DynoAIAutotune(ConfigurableChannelProvider):
             elif detected_mode == "single_rear":
                 args.extend(["--single-cylinder", "rear"])
 
-            rc, stdout, stderr = run_cli(args, timeout_seconds=CLI_TIMEOUT_SECONDS)
+            rc, stdout, stderr = run_cli(args,
+                                         timeout_seconds=CLI_TIMEOUT_SECONDS)
             if rc != 0:
                 _show_cli_error(rc, stdout, stderr)
                 return
@@ -1771,16 +1744,16 @@ class DynoAIAutotune(ConfigurableChannelProvider):
             summary = _load_summary(summary_path)
             action = show_preview(summary, Path.GetDirectoryName(summary_path))
             if action == "apply":
-                self._perform_apply(summary, summary_path, temp_dir, file_handle)
+                self._perform_apply(summary, summary_path, temp_dir,
+                                    file_handle)
                 return
             if action != "export":
                 return
 
             export_dir = _copy_export_outputs(summary, summary_path)
             msg = (
-                "Export complete.\n\nSaved files to:\n%s\n\nOpen folder now?"
-                % export_dir
-            )
+                "Export complete.\n\nSaved files to:\n%s\n\nOpen folder now?" %
+                export_dir)
             result = MessageBox.Show(
                 msg,
                 APP_TITLE_SHORT,

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -1,8 +1,16 @@
 # api/services/integrations/powercore/dynoai_autotune.py
-# DynoAI TuneLab autotune preview bridge (F1).
+# DynoAI TuneLab autotune preview + apply bridge (F1).
 #
-# IronPython 2.7 script loaded by Power Core TuneLab.
-# Preview/export only: no PutTable writes in this release.
+# IronPython 2.7 script loaded by Power Core TuneLab. Provides three actions
+# from the preview dialog:
+#   - Preview / Export Only:  copies summary + correction CSVs into
+#                             runs/<run_id>/corrections/, no tune writes.
+#   - Apply (dual-cylinder):  shells the CLI in apply mode, then writes the
+#                             reconciled VE tables back via context.PutTable.
+#   - Cancel:                 closes the dialog with no side effects.
+# Apply is gated by safety_gates.check_block_conditions on the server side
+# (extreme correction / shape mismatch / partial cylinder / invalid base VE)
+# before any PutTable can run.
 # mypy: ignore-errors
 # fmt: off
 # isort: skip_file

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -1418,8 +1418,16 @@ def _copy_export_outputs(summary, summary_path, extra_files=None):
     if not run_id:
         raise RuntimeError("Summary missing run_id; cannot resolve export destination.")
 
+    # Sanitize each path segment so a hostile or accidentally-malformed
+    # run_id (".." or absolute paths) cannot escape DEFAULT_REPO_ROOT/runs.
+    raw_parts = [part for part in run_id.split("/") if part.strip()]
+    safe_parts = [_safe_run_slug(part) for part in raw_parts]
+    safe_parts = [part for part in safe_parts if part and part not in (".", "..")]
+    if not safe_parts:
+        raise RuntimeError("Summary run_id resolves to empty segments after sanitization.")
+
     dest_dir = Path.Combine(DEFAULT_REPO_ROOT, "runs")
-    for part in run_id.split("/"):
+    for part in safe_parts:
         dest_dir = Path.Combine(dest_dir, part)
     dest_dir = Path.Combine(dest_dir, "corrections")
     Directory.CreateDirectory(dest_dir)

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -12,7 +12,8 @@
 # (extreme correction / shape mismatch / partial cylinder / invalid base VE)
 # before any PutTable can run.
 # mypy: ignore-errors
-# ruff: noqa: E402,SIM105,UP031,UP034,UP015,B904
+# ruff: noqa: E402,SIM105,UP015,UP030,UP031,UP032,UP034,B904
+# pylint: disable=C0209
 # fmt: off
 # isort: skip_file
 # autopep8: off
@@ -118,7 +119,7 @@ def _safe_run_slug(run_id):
 
     Mirrors tools.autotune.tunelab_entrypoint._safe_run_slug so a single
     run_id sanitizer is applied on both sides of the CLI boundary. Strips
-    `..`, slashes, and any non [A-Za-z0-9._-] characters; collapses runs of
+    `..`, slashes, and any non [A-Za-z0-9_-] characters; collapses runs of
     invalid characters into a single underscore. Returns "run" if the
     result is empty so we never produce a zero-length path segment.
     """
@@ -525,9 +526,7 @@ def _value_at_or_before(samples, target_ms, idx_hint):
     """Step forward through a sorted sample list and return latest <= target."""
     if not samples:
         return None, idx_hint
-    idx = idx_hint
-    if idx < 0:
-        idx = 0
+    idx = max(idx_hint, 0)
     while (idx + 1) < len(samples) and samples[idx + 1][0] <= target_ms:
         idx += 1
     if samples[idx][0] > target_ms:
@@ -540,6 +539,15 @@ def _create_temp_dir():
                             "dynoai_autotune_" + Guid.NewGuid().ToString("N"))
     Directory.CreateDirectory(temp_dir)
     return temp_dir
+
+
+# skipcq: PTC-W6004
+def _validate_csv_write_path(csv_path):
+    """Require generated CSV paths to stay under the process temp directory."""
+    full_path = Path.GetFullPath(csv_path)
+    temp_root = Path.GetFullPath(Path.GetTempPath())
+    if not full_path.lower().startswith(temp_root.lower()):
+        raise RuntimeError("CSV export path must remain under temp root.")
 
 
 def _safe_delete_dir(path_value):
@@ -587,7 +595,7 @@ def _derive_log_stem(file_handle):
 def _build_run_id(file_handle):
     date_part = DateTime.Now.ToString("yyyyMMdd")
     stem = _derive_log_stem(file_handle)
-    return "auto/%s/%s" % (date_part, stem)
+    return "auto/{0}/{1}".format(date_part, stem)
 
 
 def _estimate_map_from_rpm(rpm_value):
@@ -668,7 +676,7 @@ def _resolve_channels(file_handle):
     }
 
 
-def _raise_channel_error(file_handle, missing, found_afr_f, found_afr_r):
+def _raise_channel_error(file_handle, missing):
     """Build the diagnostic error dialog for missing required channels."""
     available = _list_channel_names(file_handle)
     file_desc = _describe_file_handle(file_handle)
@@ -679,7 +687,7 @@ def _raise_channel_error(file_handle, missing, found_afr_f, found_afr_r):
         extra_lines = [
             "",
             "Selected file: " + file_desc,
-            "Detected channels (%d):" % len(available),
+            "Detected channels ({0}):".format(len(available)),
             preview + ("..." if len(available) > 40 else ""),
         ]
     else:
@@ -738,6 +746,7 @@ def _select_best_file_handle(file_handles):
     return best_handle if best_handle is not None else file_handles[-1]
 
 
+# skipcq: PY-R1000
 def _export_loaded_log_csv(file_handle, csv_path):
     """Export loaded channels to a DynoAI-format CSV. Returns (rows, mode).
 
@@ -761,8 +770,7 @@ def _export_loaded_log_csv(file_handle, csv_path):
         missing.append("AFR Front")
         missing.append("AFR Rear")
     if missing:
-        _raise_channel_error(file_handle, missing, afr_f_ch is not None,
-                             afr_r_ch is not None)
+        _raise_channel_error(file_handle, missing)
 
     rpm_samples = _read_samples(rpm_ch)
     map_samples = _read_samples(map_ch)
@@ -786,7 +794,7 @@ def _export_loaded_log_csv(file_handle, csv_path):
             missing.append("AFR Rear")
         else:
             missing.append("AFR Rear (no samples)")
-        _raise_channel_error(file_handle, missing, False, False)
+        _raise_channel_error(file_handle, missing)
 
     if front_has_data and rear_has_data:
         mode = "dual"
@@ -807,6 +815,7 @@ def _export_loaded_log_csv(file_handle, csv_path):
     tps_idx = 0
     row_count = 0
 
+    _validate_csv_write_path(csv_path)
     with open(csv_path, "wb") as handle:
         header = ["timestamp_ms", "Engine RPM", "MAP kPa"]
         if front_has_data:
@@ -828,8 +837,8 @@ def _export_loaded_log_csv(file_handle, csv_path):
 
             row_values = [
                 t_ms,
-                "%.3f" % rpm_value,
-                "%.3f" % map_value,
+                "{0:.3f}".format(rpm_value),
+                "{0:.3f}".format(map_value),
             ]
 
             if front_has_data:
@@ -837,18 +846,18 @@ def _export_loaded_log_csv(file_handle, csv_path):
                     afr_f_samples, t_ms, afr_f_idx)
                 if afr_f_value is None:
                     continue
-                row_values.append("%.3f" % afr_f_value)
+                row_values.append("{0:.3f}".format(afr_f_value))
             if rear_has_data:
                 afr_r_value, afr_r_idx = _value_at_or_before(
                     afr_r_samples, t_ms, afr_r_idx)
                 if afr_r_value is None:
                     continue
-                row_values.append("%.3f" % afr_r_value)
+                row_values.append("{0:.3f}".format(afr_r_value))
             if tps_samples:
                 tps_value, tps_idx = _value_at_or_before(
                     tps_samples, t_ms, tps_idx)
-                row_values.append("" if tps_value is None else ("%.3f" %
-                                                                tps_value))
+                row_values.append(
+                    "" if tps_value is None else "{0:.3f}".format(tps_value))
 
             handle.write(",".join([str(v) for v in row_values]) + "\n")
             row_count += 1

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -856,8 +856,8 @@ def _export_loaded_log_csv(file_handle, csv_path):
             if tps_samples:
                 tps_value, tps_idx = _value_at_or_before(
                     tps_samples, t_ms, tps_idx)
-                row_values.append(
-                    "" if tps_value is None else "{0:.3f}".format(tps_value))
+                row_values.append("" if tps_value is
+                                  None else "{0:.3f}".format(tps_value))
 
             handle.write(",".join([str(v) for v in row_values]) + "\n")
             row_count += 1

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -1,0 +1,1720 @@
+# api/services/integrations/powercore/dynoai_autotune.py
+# DynoAI TuneLab autotune preview bridge (F1).
+#
+# IronPython 2.7 script loaded by Power Core TuneLab.
+# Preview/export only: no PutTable writes in this release.
+# mypy: ignore-errors
+
+try:
+    import json as _py_json
+except Exception:
+    _py_json = None
+
+import re
+import clr
+
+clr.AddReference("System")
+clr.AddReference("System.Windows.Forms")
+clr.AddReference("System.Drawing")
+
+from System import DateTime, Environment, Guid
+from System.Diagnostics import Process, ProcessStartInfo
+try:
+    from System.Drawing import Color, Point, Size
+except Exception:
+    from Drawing import Color, Point, Size
+from System.IO import Directory, File, Path
+from System.Windows.Forms import (
+    Button,
+    DialogResult,
+    Form,
+    FormBorderStyle,
+    FormStartPosition,
+    GroupBox,
+    Label,
+    MessageBox,
+    MessageBoxButtons,
+    MessageBoxIcon,
+)
+from tunelab import ConfigurableChannelProvider
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_REPO_ROOT = r"C:\Dev\DynoAI_3"
+DEFAULT_PYTHON = r"C:\Dev\DynoAI_3\.venv\Scripts\python.exe"
+BRIDGE_VERSION = "v1.0.0"
+APP_TITLE = "DynoAI Autotune (Preview) " + BRIDGE_VERSION
+APP_TITLE_SHORT = "DynoAI Autotune"
+WARN_THRESHOLD_PCT = 10.0
+CLI_TIMEOUT_SECONDS = 60
+APPLY_TIMEOUT_SECONDS = 120
+VE_FRONT_TABLE_NAME = "Volumetric Efficiency Front"
+VE_REAR_TABLE_NAME = "Volumetric Efficiency Rear"
+APPLY_MAX_ADJUST_PCT = 15.0
+
+VE_FRONT_TABLE_CANDIDATES = [
+    VE_FRONT_TABLE_NAME,
+    "VE Front",
+    "Volumetric Efficiency - Front",
+    "Volumetric Efficiency Front Cylinder",
+]
+VE_REAR_TABLE_CANDIDATES = [
+    VE_REAR_TABLE_NAME,
+    "VE Rear",
+    "Volumetric Efficiency - Rear",
+    "Volumetric Efficiency Rear Cylinder",
+]
+
+RPM_CHANNEL_ALIASES = [
+    "Engine RPM",
+    "RPM",
+    "Engine Speed",
+    "EngineSpeed",
+    "RPM (Engine)",
+    "Engine",
+]
+MAP_CHANNEL_ALIASES = [
+    "MAP kPa",
+    "MAP",
+    "MAP_kPa",
+    "MAP (kPa)",
+    "MAP Front",
+    "MAP Rear",
+    "Manifold Pressure",
+    "Manifold Absolute Pressure",
+    "Intake Manifold Pressure",
+    "MAP Pressure",
+    "MAP (Engine)",
+    "Intake MAP",
+]
+AFR_F_ALIASES = [
+    "WBO2 AFR Front",
+    "AFR Front",
+    "AFR F",
+    "AFR 1",
+    "AFR #1",
+    "AFR_1",
+    "AFR 1F",
+    "AFR F1",
+    "AFR1",
+    "AFR Meas F",
+    "A/F Ratio 1",
+    "A/F 1",
+    "A/F F",
+    "Air/Fuel Ratio 1",
+    "Air/Fuel Ratio F",
+    "Air Fuel Ratio 1",
+    "WBO2 F",
+    "WBO2F",
+    "WBO2 #1",
+    "WB O2 F",
+    "Wideband F",
+    "Wideband 1",
+    "Wideband AFR 1",
+    "Wideband AFR F",
+    "DLG-1 AFR F",
+    "DLG AFR F",
+    "LC-1 AFR F",
+    "LC-2 AFR F",
+    "LC2 AFR F",
+    "LC1 AFR F",
+    "Innovate AFR F",
+]
+AFR_R_ALIASES = [
+    "WBO2 AFR Rear",
+    "AFR Rear",
+    "AFR R",
+    "AFR 2",
+    "AFR #2",
+    "AFR_2",
+    "AFR 2R",
+    "AFR R2",
+    "AFR2",
+    "AFR Meas R",
+    "A/F Ratio 2",
+    "A/F 2",
+    "A/F R",
+    "Air/Fuel Ratio 2",
+    "Air/Fuel Ratio R",
+    "Air Fuel Ratio 2",
+    "WBO2 R",
+    "WBO2R",
+    "WBO2 #2",
+    "WB O2 R",
+    "Wideband R",
+    "Wideband 2",
+    "Wideband AFR 2",
+    "Wideband AFR R",
+    "DLG-1 AFR R",
+    "DLG AFR R",
+    "LC-1 AFR R",
+    "LC-2 AFR R",
+    "LC2 AFR R",
+    "LC1 AFR R",
+    "Innovate AFR R",
+]
+# Lambda aliases — distinct from AFR aliases. Lambda values are 0-2; they
+# MUST be converted to AFR by the CLI (tools.autotune.tunelab_entrypoint
+# calls api.services.jetdrive.jetdrive_mapping.lambda_to_afr).
+AFR_F_LAMBDA_ALIASES = [
+    "WBO2 LAMBDA Front",
+    "Lambda Front",
+    "Lambda F",
+    "Lambda 1",
+    "AT Lambda 1",
+    "LC-1 Lambda F",
+    "LC-2 Lambda F",
+    "Wideband Lambda F",
+    "Wideband Lambda 1",
+]
+AFR_R_LAMBDA_ALIASES = [
+    "WBO2 LAMBDA Rear",
+    "Lambda Rear",
+    "Lambda R",
+    "Lambda 2",
+    "AT Lambda 2",
+    "LC-1 Lambda R",
+    "LC-2 Lambda R",
+    "Wideband Lambda R",
+    "Wideband Lambda 2",
+]
+AFR_F_VOLT_ALIASES = [
+    "LC2 Volts Petrol AFR1",
+    "LC-2 Volts Petrol AFR1",
+    "LC2 Volts AFR1",
+    "LC-2 Volts AFR1",
+    "LC1 Volts AFR1",
+    "WBO2 F Volts",
+    "WBO2 Volts F",
+    "Wideband Volts F",
+    "Wideband Volts 1",
+    "Innovate Volts F",
+    "Innovate Volts 1",
+    "AFR Volts F",
+    "AFR Volts 1",
+]
+AFR_R_VOLT_ALIASES = [
+    "LC2 Volts Petrol AFR2",
+    "LC-2 Volts Petrol AFR2",
+    "LC2 Volts AFR2",
+    "LC-2 Volts AFR2",
+    "LC1 Volts AFR2",
+    "WBO2 R Volts",
+    "WBO2 Volts R",
+    "Wideband Volts R",
+    "Wideband Volts 2",
+    "Innovate Volts R",
+    "Innovate Volts 2",
+    "AFR Volts R",
+    "AFR Volts 2",
+]
+TPS_ALIASES = [
+    "TPS",
+    "TP",
+    "Throttle Position",
+    "Throttle",
+    "Throttle Position Sensor",
+]
+
+# Broad probe list for diagnostics when strict aliases fail.
+DIAG_PROBE_NAMES = (
+    RPM_CHANNEL_ALIASES
+    + MAP_CHANNEL_ALIASES
+    + AFR_F_ALIASES
+    + AFR_R_ALIASES
+    + AFR_F_VOLT_ALIASES
+    + AFR_R_VOLT_ALIASES
+    + TPS_ALIASES
+    + [
+        "B+",
+        "VBatt",
+        "Battery",
+        "Battery Voltage",
+        "ET",
+        "Engine Temp",
+        "ECT",
+        "Coolant Temp",
+        "Engine Temperature",
+        "IAT",
+        "Intake Air Temp",
+        "Intake Temperature",
+        "Vehicle Speed",
+        "Gear",
+        "Spark Advance",
+        "Ignition Timing",
+        "Injector Duty",
+        "Injector Pulse Width",
+        "Fuel Pressure",
+        "Oil Pressure",
+        "Oil Temp",
+        "Knock",
+        "Knock Retard",
+        "Horsepower",
+        "HP",
+        "Torque",
+        "TQ",
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _decode(data):
+    """Decode process output into a string, tolerating mixed encodings."""
+    if data is None:
+        return ""
+    try:
+        if isinstance(data, unicode):
+            return data
+    except NameError:
+        pass
+    if isinstance(data, str):
+        try:
+            return data.decode("utf-8")
+        except Exception:
+            try:
+                return data.decode("cp1252", "replace")
+            except Exception:
+                return data
+    return data
+
+
+def _resolve_python():
+    if File.Exists(DEFAULT_PYTHON):
+        return DEFAULT_PYTHON
+    return "python"
+
+
+def _quote_arg(arg):
+    s = str(arg)
+    if s == "":
+        return '""'
+    if '"' in s:
+        s = s.replace('"', '\\"')
+    if (" " in s) or ("\t" in s):
+        return '"' + s + '"'
+    return s
+
+
+def run_cli(args, timeout_seconds):
+    """Run the Python CLI via .NET ProcessStartInfo."""
+    psi = ProcessStartInfo()
+    psi.FileName = _resolve_python()
+    psi.Arguments = " ".join([_quote_arg(a) for a in args])
+    psi.WorkingDirectory = DEFAULT_REPO_ROOT
+    psi.UseShellExecute = False
+    psi.RedirectStandardOutput = True
+    psi.RedirectStandardError = True
+    psi.CreateNoWindow = True
+
+    proc = Process()
+    proc.StartInfo = psi
+    proc.Start()
+
+    raw_out = proc.StandardOutput.ReadToEnd()
+    raw_err = proc.StandardError.ReadToEnd()
+    if not proc.WaitForExit(int(timeout_seconds * 1000)):
+        try:
+            proc.Kill()
+        except Exception:
+            pass
+        return 124, _decode(raw_out), "[F1][ERR] cli_timeout"
+
+    return proc.ExitCode, _decode(raw_out), _decode(raw_err)
+
+
+def _extract_summary_path(stdout):
+    if not stdout:
+        return None
+    for line in stdout.splitlines():
+        trimmed = line.strip()
+        if trimmed.startswith("[F1][OK] summary="):
+            return trimmed.split("=", 1)[1].strip()
+    return None
+
+
+def _extract_f1_error(stderr):
+    if not stderr:
+        return None
+    for line in stderr.splitlines():
+        trimmed = line.strip()
+        if trimmed.startswith("[F1][ERR]"):
+            return trimmed
+    return None
+
+
+def _try_channel(file_handle, aliases):
+    for name in aliases:
+        try:
+            ch = channels.GetChannelByName(name, file_handle)  # noqa: F821
+            if ch is not None:
+                return ch
+        except Exception:
+            continue
+    return None
+
+
+def _list_channel_names(file_handle):
+    """Best-effort enumeration of channel names in a loaded file.
+
+    First tries several real TuneLab enumeration APIs (which vary by build).
+    If none exist, falls back to probing DIAG_PROBE_NAMES via GetChannelByName
+    so the user can still see which common channels are present.
+    """
+    names = []
+    seen = set()
+
+    def _add(value):
+        try:
+            s = str(value)
+        except Exception:
+            return
+        if not s or s in seen:
+            return
+        seen.add(s)
+        names.append(s)
+
+    candidates = [
+        lambda: getattr(file_handle, "Channels", None),
+        lambda: getattr(file_handle, "ChannelNames", None),
+        lambda: channels.GetChannels(file_handle),  # noqa: F821
+        lambda: channels.GetAllChannels(file_handle),  # noqa: F821
+        lambda: channels.GetChannelNames(file_handle),  # noqa: F821
+        lambda: channels.ListChannels(file_handle),  # noqa: F821
+    ]
+
+    for getter in candidates:
+        try:
+            result = getter()
+        except Exception:
+            continue
+        if result is None:
+            continue
+        try:
+            for item in result:
+                name_attr = getattr(item, "Name", None) or getattr(item, "name", None)
+                if name_attr is not None:
+                    _add(name_attr)
+                else:
+                    _add(item)
+        except Exception:
+            continue
+
+    if names:
+        return names
+
+    # Fallback: actively probe known names via GetChannelByName.
+    for name in DIAG_PROBE_NAMES:
+        try:
+            ch = channels.GetChannelByName(name, file_handle)  # noqa: F821
+        except Exception:
+            ch = None
+        if ch is not None:
+            _add(name)
+
+    return names
+
+
+def _describe_file_handle(file_handle):
+    """Return a short human string describing a loaded file handle."""
+    for attr in ["FilePath", "Path", "FileName", "Name"]:
+        try:
+            value = getattr(file_handle, attr)
+        except Exception:
+            value = None
+        if value:
+            return str(value)
+    return str(file_handle)
+
+
+def _read_samples(channel):
+    samples = []
+    if channel is None:
+        return samples
+    for sample in channel.GetAllSamples():
+        try:
+            t_ms = int(sample.TimeMillis)
+            value = float(sample.Value)
+        except Exception:
+            continue
+        samples.append((t_ms, value))
+    return samples
+
+
+def _value_at_or_before(samples, target_ms, idx_hint):
+    """Step forward through a sorted sample list and return latest <= target."""
+    if not samples:
+        return None, idx_hint
+    idx = idx_hint
+    if idx < 0:
+        idx = 0
+    while (idx + 1) < len(samples) and samples[idx + 1][0] <= target_ms:
+        idx += 1
+    if samples[idx][0] > target_ms:
+        return None, idx
+    return samples[idx][1], idx
+
+
+def _create_temp_dir():
+    temp_dir = Path.Combine(
+        Path.GetTempPath(), "dynoai_autotune_" + Guid.NewGuid().ToString("N")
+    )
+    Directory.CreateDirectory(temp_dir)
+    return temp_dir
+
+
+def _safe_delete_dir(path_value):
+    if not path_value:
+        return
+    try:
+        if Directory.Exists(path_value):
+            Directory.Delete(path_value, True)
+    except Exception:
+        pass
+
+
+def _sanitize_name(raw):
+    if not raw:
+        return "loaded_log"
+    chars = []
+    for ch in str(raw):
+        if ch.isalnum() or ch in ("-", "_"):
+            chars.append(ch)
+        else:
+            chars.append("_")
+    value = "".join(chars).strip("_")
+    if not value:
+        return "loaded_log"
+    return value
+
+
+def _derive_log_stem(file_handle):
+    for attr in ["FilePath", "Path", "FileName", "Name"]:
+        try:
+            value = getattr(file_handle, attr)
+        except Exception:
+            value = None
+        if value:
+            try:
+                stem = Path.GetFileNameWithoutExtension(str(value))
+            except Exception:
+                stem = str(value)
+            if stem:
+                return _sanitize_name(stem)
+    return "loaded_log"
+
+
+def _build_run_id(file_handle):
+    date_part = DateTime.Now.ToString("yyyyMMdd")
+    stem = _derive_log_stem(file_handle)
+    return "auto/%s/%s" % (date_part, stem)
+
+
+def _estimate_map_from_rpm(rpm_value):
+    try:
+        rpm = float(rpm_value)
+    except Exception:
+        return 60.0
+    if rpm < 2000:
+        return 35.0
+    if rpm < 3500:
+        return 50.0
+    if rpm < 5000:
+        return 65.0
+    return 80.0
+
+
+def _resolve_afr_or_voltage(file_handle, afr_aliases, volt_aliases, lambda_aliases=None):
+    """Resolve AFR input: prefer AFR-unit, fall back to voltage, then Lambda.
+
+    Returns (channel, column_name). ``column_name`` is:
+        - None when the channel is an AFR-unit channel (caller uses canonical
+          "AFR Meas F/R" header).
+        - A raw voltage alias when a voltage wideband channel is selected
+          (CLI converts via wideband_rescale.canonicalize_wideband_sample).
+        - A raw lambda alias when only Lambda is available (CLI converts via
+          jetdrive_mapping.lambda_to_afr).
+    """
+    afr_ch = _try_channel(file_handle, afr_aliases)
+    if afr_ch is not None:
+        return afr_ch, None
+
+    for name in volt_aliases:
+        try:
+            ch = channels.GetChannelByName(name, file_handle)  # noqa: F821
+        except Exception:
+            ch = None
+        if ch is not None:
+            return ch, name
+
+    if lambda_aliases:
+        for name in lambda_aliases:
+            try:
+                ch = channels.GetChannelByName(name, file_handle)  # noqa: F821
+            except Exception:
+                ch = None
+            if ch is not None:
+                return ch, name
+
+    return None, None
+
+
+def _resolve_channels(file_handle):
+    """Probe all required channels without raising.
+
+    Returns a dict with resolved channels and voltage-mode names. Callers
+    decide how to handle missing sides (dual vs single-cylinder).
+    """
+    rpm_ch = _try_channel(file_handle, RPM_CHANNEL_ALIASES)
+    map_ch = _try_channel(file_handle, MAP_CHANNEL_ALIASES)
+    afr_f_ch, front_volt_name = _resolve_afr_or_voltage(
+        file_handle, AFR_F_ALIASES, AFR_F_VOLT_ALIASES, AFR_F_LAMBDA_ALIASES
+    )
+    afr_r_ch, rear_volt_name = _resolve_afr_or_voltage(
+        file_handle, AFR_R_ALIASES, AFR_R_VOLT_ALIASES, AFR_R_LAMBDA_ALIASES
+    )
+    tps_ch = _try_channel(file_handle, TPS_ALIASES)
+    return {
+        "rpm_ch": rpm_ch,
+        "map_ch": map_ch,
+        "afr_f_ch": afr_f_ch,
+        "afr_r_ch": afr_r_ch,
+        "tps_ch": tps_ch,
+        "front_volt_name": front_volt_name,
+        "rear_volt_name": rear_volt_name,
+    }
+
+
+def _raise_channel_error(file_handle, missing, found_afr_f, found_afr_r):
+    """Build the diagnostic error dialog for missing required channels."""
+    available = _list_channel_names(file_handle)
+    file_desc = _describe_file_handle(file_handle)
+    nl = "\r\n"
+
+    if available:
+        preview = ", ".join(available[:40])
+        extra_lines = [
+            "",
+            "Selected file: " + file_desc,
+            "Detected channels (%d):" % len(available),
+            preview + ("..." if len(available) > 40 else ""),
+        ]
+    else:
+        extra_lines = [
+            "",
+            "Selected file: " + file_desc,
+            "No known channels resolved via GetChannelByName or",
+            "enumeration APIs. Check that the correct log is loaded",
+            "in Data Center.",
+        ]
+
+    extra = nl.join(extra_lines)
+
+    if ("AFR Front" in missing) or ("AFR Rear" in missing):
+        raise RuntimeError(
+            "Cannot find any AFR channel in the loaded log." + nl
+            + "Missing: " + ", ".join(missing) + extra
+        )
+    raise RuntimeError(
+        "Missing required channels: " + ", ".join(missing) + extra
+    )
+
+
+def _channel_score(file_handle):
+    score = 0
+    rpm_ch = _try_channel(file_handle, RPM_CHANNEL_ALIASES)
+    map_ch = _try_channel(file_handle, MAP_CHANNEL_ALIASES)
+    afr_f_ch, front_raw_name = _resolve_afr_or_voltage(
+        file_handle, AFR_F_ALIASES, AFR_F_VOLT_ALIASES, AFR_F_LAMBDA_ALIASES
+    )
+    afr_r_ch, rear_raw_name = _resolve_afr_or_voltage(
+        file_handle, AFR_R_ALIASES, AFR_R_VOLT_ALIASES, AFR_R_LAMBDA_ALIASES
+    )
+    if rpm_ch is not None:
+        score += 1
+    if map_ch is not None:
+        score += 1
+    # Prefer AFR-unit channels over voltage/lambda (which need conversion).
+    if afr_f_ch is not None:
+        score += 2 if front_raw_name is None else 1
+    if afr_r_ch is not None:
+        score += 2 if rear_raw_name is None else 1
+    return score
+
+
+def _select_best_file_handle(file_handles):
+    if not file_handles:
+        return None
+    # Prefer the file that actually carries dual-cylinder AFR + RPM signals.
+    best_handle = None
+    best_score = -1
+    for fh in file_handles:
+        score = _channel_score(fh)
+        if score > best_score:
+            best_score = score
+            best_handle = fh
+    return best_handle if best_handle is not None else file_handles[-1]
+
+
+def _export_loaded_log_csv(file_handle, csv_path):
+    """Export loaded channels to a DynoAI-format CSV. Returns (rows, mode).
+
+    mode is one of "dual", "single_front", "single_rear". When a cylinder's
+    AFR channel is missing or has no samples, its column is simply omitted
+    from the CSV and the CLI gets --single-cylinder on the remaining side.
+    """
+    resolved = _resolve_channels(file_handle)
+    rpm_ch = resolved["rpm_ch"]
+    map_ch = resolved["map_ch"]
+    afr_f_ch = resolved["afr_f_ch"]
+    afr_r_ch = resolved["afr_r_ch"]
+    tps_ch = resolved["tps_ch"]
+    front_volt_name = resolved["front_volt_name"]
+    rear_volt_name = resolved["rear_volt_name"]
+
+    missing = []
+    if rpm_ch is None:
+        missing.append("RPM")
+    if afr_f_ch is None and afr_r_ch is None:
+        missing.append("AFR Front")
+        missing.append("AFR Rear")
+    if missing:
+        _raise_channel_error(file_handle, missing, afr_f_ch is not None, afr_r_ch is not None)
+
+    rpm_samples = _read_samples(rpm_ch)
+    map_samples = _read_samples(map_ch)
+    afr_f_samples = _read_samples(afr_f_ch) if afr_f_ch is not None else []
+    afr_r_samples = _read_samples(afr_r_ch) if afr_r_ch is not None else []
+    tps_samples = _read_samples(tps_ch)
+
+    if not rpm_samples:
+        raise RuntimeError("RPM channel has no samples.")
+
+    front_has_data = bool(afr_f_samples)
+    rear_has_data = bool(afr_r_samples)
+
+    if not front_has_data and not rear_has_data:
+        missing = []
+        if afr_f_ch is None:
+            missing.append("AFR Front")
+        else:
+            missing.append("AFR Front (no samples)")
+        if afr_r_ch is None:
+            missing.append("AFR Rear")
+        else:
+            missing.append("AFR Rear (no samples)")
+        _raise_channel_error(file_handle, missing, False, False)
+
+    if front_has_data and rear_has_data:
+        mode = "dual"
+    elif front_has_data:
+        mode = "single_front"
+    else:
+        mode = "single_rear"
+
+    # Preserve the raw voltage channel name so the CLI can detect and
+    # convert via api.services.jetdrive.wideband_rescale (single point of
+    # conversion). For AFR-unit channels we use the canonical column name.
+    front_col = front_volt_name or "AFR Meas F"
+    rear_col = rear_volt_name or "AFR Meas R"
+
+    map_idx = 0
+    afr_f_idx = 0
+    afr_r_idx = 0
+    tps_idx = 0
+    row_count = 0
+
+    with open(csv_path, "wb") as handle:
+        header = ["timestamp_ms", "Engine RPM", "MAP kPa"]
+        if front_has_data:
+            header.append(front_col)
+        if rear_has_data:
+            header.append(rear_col)
+        if tps_samples:
+            header.append("TPS")
+        handle.write((",".join(header) + "\n"))
+
+        for t_ms, rpm_value in rpm_samples:
+            if map_samples:
+                map_value, map_idx = _value_at_or_before(map_samples, t_ms, map_idx)
+            else:
+                map_value = _estimate_map_from_rpm(rpm_value)
+            if map_value is None:
+                continue
+
+            row_values = [
+                t_ms,
+                "%.3f" % rpm_value,
+                "%.3f" % map_value,
+            ]
+
+            if front_has_data:
+                afr_f_value, afr_f_idx = _value_at_or_before(
+                    afr_f_samples, t_ms, afr_f_idx
+                )
+                if afr_f_value is None:
+                    continue
+                row_values.append("%.3f" % afr_f_value)
+            if rear_has_data:
+                afr_r_value, afr_r_idx = _value_at_or_before(
+                    afr_r_samples, t_ms, afr_r_idx
+                )
+                if afr_r_value is None:
+                    continue
+                row_values.append("%.3f" % afr_r_value)
+            if tps_samples:
+                tps_value, tps_idx = _value_at_or_before(tps_samples, t_ms, tps_idx)
+                row_values.append("" if tps_value is None else ("%.3f" % tps_value))
+
+            handle.write(",".join([str(v) for v in row_values]) + "\n")
+            row_count += 1
+
+    if row_count == 0:
+        raise RuntimeError("No aligned rows could be exported from loaded channels.")
+
+    return row_count, mode
+
+
+def _dotnet_to_python(value):
+    """Recursively convert .NET Dictionary/List to native Python dict/list.
+
+    ``JavaScriptSerializer.DeserializeObject`` returns .NET containers:
+        JSON object -> System.Collections.Generic.Dictionary[str, object]
+        JSON array  -> object[]
+        primitives  -> mapped to IronPython native types
+
+    These .NET containers do not support ``.get``, have different truthy
+    semantics, and break downstream code expecting dicts/lists. Convert
+    eagerly at the deserialize boundary so every caller is on Python types.
+    """
+    if value is None:
+        return None
+
+    # Bool first (bool is also an int in IronPython; keep it a Python bool).
+    if isinstance(value, bool):
+        return bool(value)
+
+    # String types: return as-is; do NOT iterate char-by-char.
+    try:
+        if isinstance(value, unicode):  # noqa: F821 - IronPython 2.7
+            return value
+    except NameError:
+        pass
+    if isinstance(value, str):
+        return value
+
+    # Dict-like: .NET Dictionary has a ``Keys`` collection.
+    try:
+        keys = value.Keys
+    except Exception:
+        keys = None
+    if keys is not None:
+        result = {}
+        try:
+            for key in keys:
+                result[str(key)] = _dotnet_to_python(value[key])
+            return result
+        except Exception:
+            # Fall through to iterable handling on unexpected shape.
+            pass
+
+    # Sequence-like: object[], List[object], any IEnumerable.
+    try:
+        items = [_dotnet_to_python(item) for item in value]
+        return items
+    except TypeError:
+        pass
+
+    # Numeric primitive or any pass-through value.
+    return value
+
+
+def _load_summary(summary_path):
+    raw_text = File.ReadAllText(summary_path)
+
+    # Prefer Python json when available.
+    if _py_json is not None:
+        try:
+            return _py_json.loads(raw_text)
+        except Exception:
+            pass
+
+    # TuneLab IronPython builds can omit json; fall back to .NET serializer.
+    try:
+        clr.AddReference("System.Web.Extensions")
+        from System.Web.Script.Serialization import JavaScriptSerializer
+
+        serializer = JavaScriptSerializer()
+        raw_value = serializer.DeserializeObject(raw_text)
+        return _dotnet_to_python(raw_value)
+    except Exception as exc:
+        raise RuntimeError("Unable to parse correction_summary.json: %s" % str(exc))
+
+
+def _to_metric(value, decimals):
+    try:
+        return ("%." + str(decimals) + "f") % float(value)
+    except Exception:
+        return str(value)
+
+
+def _safe_get(mapping, key, default=None):
+    """Read a key from either a Python dict or a .NET Dictionary.
+
+    After ``_load_summary`` runs the ``_dotnet_to_python`` conversion this
+    should always hit the Python dict path, but keeping a fallback makes
+    the dialog code robust against any future deserializer regression.
+    """
+    if mapping is None:
+        return default
+    try:
+        return mapping.get(key, default)
+    except AttributeError:
+        pass
+    try:
+        if mapping.ContainsKey(key):
+            return mapping[key]
+    except Exception:
+        pass
+    try:
+        return mapping[key]
+    except Exception:
+        return default
+
+
+def _json_dumps(value):
+    if _py_json is not None:
+        try:
+            return _py_json.dumps(value)
+        except Exception:
+            pass
+    try:
+        clr.AddReference("System.Web.Extensions")
+        from System.Web.Script.Serialization import JavaScriptSerializer
+
+        serializer = JavaScriptSerializer()
+        return serializer.Serialize(value)
+    except Exception:
+        return str(value)
+
+
+def _format_axis_value(value):
+    try:
+        as_float = float(value)
+    except Exception:
+        return str(value)
+    if int(as_float) == as_float:
+        return str(int(as_float))
+    text = "%.3f" % as_float
+    return text.rstrip("0").rstrip(".")
+
+
+def _coerce_float(value):
+    text = str(value).strip()
+    if text.startswith("'"):
+        text = text[1:]
+    return float(text)
+
+
+def _parse_ve_csv(csv_path):
+    if not File.Exists(csv_path):
+        raise RuntimeError("Missing CSV: %s" % csv_path)
+
+    with open(csv_path, "r") as handle:
+        lines = handle.readlines()
+    if not lines:
+        raise RuntimeError("Empty CSV: %s" % csv_path)
+
+    header_parts = [p.strip() for p in lines[0].strip().split(",")]
+    if len(header_parts) < 2:
+        raise RuntimeError("Invalid VE CSV header: %s" % csv_path)
+
+    map_axis = [_coerce_float(v) for v in header_parts[1:]]
+    rpm_axis = []
+    grid = []
+    for line in lines[1:]:
+        raw = line.strip()
+        if not raw:
+            continue
+        parts = [p.strip() for p in raw.split(",")]
+        if len(parts) < 2:
+            continue
+        rpm_axis.append(_coerce_float(parts[0]))
+        row = []
+        for idx in range(1, len(map_axis) + 1):
+            if idx < len(parts) and parts[idx] != "":
+                row.append(_coerce_float(parts[idx]))
+            else:
+                row.append(0.0)
+        grid.append(row)
+    if not rpm_axis:
+        raise RuntimeError("No VE rows in CSV: %s" % csv_path)
+    return rpm_axis, map_axis, grid
+
+
+def _write_ve_csv(csv_path, rpm_axis, map_axis, grid):
+    with open(csv_path, "wb") as handle:
+        header = ["RPM"] + [_format_axis_value(v) for v in map_axis]
+        handle.write((",".join(header) + "\n"))
+        for rpm, row in zip(rpm_axis, grid):
+            values = ["%.6f" % float(v) for v in row]
+            handle.write((_format_axis_value(rpm) + "," + ",".join(values) + "\n"))
+
+
+def _table_get_value(table_obj, row_idx, col_idx):
+    accessors = [
+        lambda t, r, c: t.GetValue(r, c),
+        lambda t, r, c: t.get_Item(r, c),
+        lambda t, r, c: t[r, c],
+    ]
+    for accessor in accessors:
+        try:
+            value = accessor(table_obj, row_idx, col_idx)
+            return float(value)
+        except Exception:
+            continue
+    try:
+        return float(table_obj[row_idx][col_idx])
+    except Exception as exc:
+        raise RuntimeError(
+            "Unable to read table cell (%d,%d): %s" % (row_idx, col_idx, str(exc))
+        )
+
+
+def _table_set_value(table_obj, row_idx, col_idx, value):
+    setters = [
+        lambda t, r, c, v: t.SetValue(r, c, v),
+        lambda t, r, c, v: t.set_Item(r, c, v),
+        lambda t, r, c, v: t.SetCell(r, c, v),
+    ]
+    for setter in setters:
+        try:
+            setter(table_obj, row_idx, col_idx, value)
+            return
+        except Exception:
+            continue
+    try:
+        table_obj[row_idx, col_idx] = value
+        return
+    except Exception:
+        pass
+    try:
+        table_obj[row_idx][col_idx] = value
+        return
+    except Exception as exc:
+        raise RuntimeError(
+            "Unable to write table cell (%d,%d): %s" % (row_idx, col_idx, str(exc))
+        )
+
+
+def _extract_table_grid(table_obj, rows, cols):
+    last_error = None
+    for base_index in (0, 1):
+        try:
+            grid = []
+            for r in range(rows):
+                row = []
+                for c in range(cols):
+                    row.append(_table_get_value(table_obj, r + base_index, c + base_index))
+                grid.append(row)
+            return grid, base_index
+        except Exception as exc:
+            last_error = exc
+            continue
+    raise RuntimeError("Unable to read table grid: %s" % str(last_error))
+
+
+def _apply_grid_to_table(table_obj, grid, base_index):
+    for r, row in enumerate(grid):
+        for c, value in enumerate(row):
+            _table_set_value(table_obj, r + base_index, c + base_index, float(value))
+
+
+def _context_probe_lines():
+    try:
+        names = [str(name) for name in dir(context)]  # noqa: F821
+    except Exception:
+        names = []
+    if not names:
+        return "context members unavailable"
+    names.sort()
+    return ", ".join(names[:80]) + ("..." if len(names) > 80 else "")
+
+
+def _resolve_table_from_candidates(candidates, expected_rows, expected_cols):
+    attempts = []
+    for name in candidates:
+        try:
+            table_obj = context.GetTable(name)  # noqa: F821
+            if table_obj is None:
+                attempts.append("%s: returned None" % name)
+                continue
+            _, base_index = _extract_table_grid(table_obj, expected_rows, expected_cols)
+            return table_obj, name, base_index
+        except Exception as exc:
+            attempts.append("%s: %s" % (name, str(exc)))
+    detail = "\r\n".join(attempts) if attempts else "No candidates attempted."
+    raise RuntimeError(
+        "Could not resolve VE table from candidates.\r\n"
+        "Candidates: %s\r\n%s\r\ncontext: %s"
+        % (", ".join(candidates), detail, _context_probe_lines())
+    )
+
+
+def _extract_apply_paths(stdout):
+    if not stdout:
+        return None
+    pattern = re.compile(
+        r"^\[F1\]\[OK\]\s+apply_front=(\S+)\s+apply_rear=(\S+)\s+session_log=(\S+)\s*$"
+    )
+    for line in stdout.splitlines():
+        match = pattern.match(line.strip())
+        if match:
+            return match.group(1), match.group(2), match.group(3)
+    return None
+
+
+def _append_apply_audit_log(
+    summary, file_desc, front_table_name, rear_table_name, session_log_path
+):
+    logs_dir = Path.Combine(DEFAULT_REPO_ROOT, "logs")
+    Directory.CreateDirectory(logs_dir)
+    audit_path = Path.Combine(logs_dir, "autotune_applied.log")
+    backup_path = Path.Combine(Path.GetDirectoryName(session_log_path), "snapshots")
+    record = {
+        "ts": DateTime.UtcNow.ToString("o"),
+        "run_id": _safe_get(summary, "run_id", ""),
+        "mode": _safe_get(summary, "mode", ""),
+        "max_pct": _safe_get(summary, "overall_max_pct", 0.0),
+        "backup_path": backup_path,
+        "tables_written": [front_table_name, rear_table_name],
+        "operator": str(Environment.UserName),
+        "log_file": file_desc,
+        "session_log": session_log_path,
+    }
+    payload = _json_dumps(record)
+    with open(audit_path, "a") as handle:
+        handle.write(payload + "\n")
+    return audit_path
+
+
+def _axes_match(expected_axis, actual_axis, epsilon=1e-6):
+    if len(expected_axis) != len(actual_axis):
+        return False
+    for expected, actual in zip(expected_axis, actual_axis):
+        try:
+            if abs(float(expected) - float(actual)) > epsilon:
+                return False
+        except Exception:
+            if str(expected) != str(actual):
+                return False
+    return True
+
+
+class PreviewDialog(Form):
+    def __init__(self, summary, preview_dir):
+        self.summary = summary
+        self.preview_dir = preview_dir
+        self.action = None
+        self._build_form()
+
+    def _build_form(self):
+        self.Text = APP_TITLE
+        self.Size = Size(560, 430)
+        self.FormBorderStyle = FormBorderStyle.FixedDialog
+        self.StartPosition = FormStartPosition.CenterScreen
+        self.MinimizeBox = False
+        self.MaximizeBox = False
+
+        banner = Label()
+        banner.Location = Point(15, 12)
+        banner.Size = Size(520, 52)
+        mode = str(_safe_get(self.summary, "mode", "dual_cylinder"))
+        safety = _safe_get(self.summary, "safety", {}) or {}
+        apply_blocked = bool(_safe_get(safety, "apply_blocked", False))
+        warn_threshold = float(_safe_get(safety, "warn_threshold_pct", WARN_THRESHOLD_PCT))
+        over_warn = bool(_safe_get(self.summary, "over_warn_threshold"))
+        if apply_blocked and mode == MODE_DUAL:
+            banner.Text = "APPLY BLOCKED: safety gates must pass before write-back."
+            banner.ForeColor = Color.Red
+        elif over_warn:
+            banner.Text = (
+                "WARNING: max correction exceeds %.0f%%. Review before any apply."
+                % warn_threshold
+            )
+            banner.ForeColor = Color.DarkOrange
+        elif mode == "single_cylinder_front":
+            banner.Text = (
+                "Single-wideband log (front). Only front correction will be exported. "
+                "Rear is unchanged."
+            )
+            banner.ForeColor = Color.DarkOrange
+        elif mode == "single_cylinder_rear":
+            banner.Text = (
+                "Single-wideband log (rear). Only rear correction will be exported. "
+                "Front is unchanged."
+            )
+            banner.ForeColor = Color.DarkOrange
+        else:
+            banner.Text = "Preview only. Review outputs before any manual flash."
+            banner.ForeColor = Color.DarkGreen
+        self.Controls.Add(banner)
+
+        front_group = self._build_cylinder_group(
+            "Front (VE F)", _safe_get(self.summary, "front"), 15
+        )
+        rear_group = self._build_cylinder_group(
+            "Rear (VE R)", _safe_get(self.summary, "rear"), 285
+        )
+        self.Controls.Add(front_group)
+        self.Controls.Add(rear_group)
+
+        # Footer details
+        footer = Label()
+        footer.Location = Point(15, 315)
+        footer.Size = Size(520, 40)
+        footer.Text = (
+            "run_id: %s\nsummary schema: v%s"
+            % (
+                _safe_get(self.summary, "run_id", "unknown"),
+                _safe_get(self.summary, "schema_version", "?"),
+            )
+        )
+        self.Controls.Add(footer)
+
+        show_apply = mode == MODE_DUAL
+        if show_apply:
+            btn_apply = Button()
+            btn_apply.Text = "Apply to Loaded Tune"
+            btn_apply.Location = Point(95, 360)
+            btn_apply.Size = Size(140, 30)
+            btn_apply.Enabled = not apply_blocked
+            btn_apply.Click += self._on_apply
+            self.Controls.Add(btn_apply)
+
+            if apply_blocked:
+                reasons = _safe_get(safety, "apply_blocked_reasons", []) or []
+                messages = []
+                for reason in reasons:
+                    if isinstance(reason, dict):
+                        msg = str(_safe_get(reason, "message", "")).strip()
+                        if msg:
+                            messages.append(msg)
+                reason_label = Label()
+                reason_label.Location = Point(15, 340)
+                reason_label.Size = Size(520, 20)
+                reason_label.ForeColor = Color.Red
+                reason_label.Text = "Blocked: %s" % (
+                    "; ".join(messages) if messages else "Unknown safety reason."
+                )
+                self.Controls.Add(reason_label)
+
+        btn_export = Button()
+        btn_export.Text = "Export Only"
+        btn_export.Location = Point(245, 360)
+        btn_export.Size = Size(90, 30)
+        btn_export.Click += self._on_export
+        self.Controls.Add(btn_export)
+
+        btn_open = Button()
+        btn_open.Text = "Open Folder"
+        btn_open.Location = Point(345, 360)
+        btn_open.Size = Size(90, 30)
+        btn_open.Click += self._on_open_folder
+        self.Controls.Add(btn_open)
+
+        btn_cancel = Button()
+        btn_cancel.Text = "Cancel"
+        btn_cancel.Location = Point(445, 360)
+        btn_cancel.Size = Size(90, 30)
+        btn_cancel.Click += self._on_cancel
+        self.Controls.Add(btn_cancel)
+
+        self.AcceptButton = btn_export
+        self.CancelButton = btn_cancel
+
+    def _build_cylinder_group(self, title, section, x):
+        group = GroupBox()
+        group.Text = title
+        group.Location = Point(x, 70)
+        group.Size = Size(255, 230)
+
+        if section is None:
+            na_label = Label()
+            na_label.Location = Point(10, 30)
+            na_label.Size = Size(235, 60)
+            na_label.Text = (
+                "Not computed.\n"
+                "This cylinder had no wideband samples\n"
+                "in the loaded log."
+            )
+            na_label.ForeColor = Color.Gray
+            group.Controls.Add(na_label)
+            return group
+
+        self._add_metric(group, "zones_adjusted", _safe_get(section, "zones_adjusted"), 30)
+        self._add_metric(
+            group,
+            "max_correction_pct",
+            _to_metric(_safe_get(section, "max_pct", 0.0), 2),
+            60,
+        )
+        self._add_metric(
+            group,
+            "min_correction_pct",
+            _to_metric(_safe_get(section, "min_pct", 0.0), 2),
+            90,
+        )
+        self._add_metric(group, "clipped_zones", _safe_get(section, "clipped_zones"), 120)
+        self._add_metric(
+            group,
+            "mean_afr_error",
+            _to_metric(_safe_get(section, "mean_afr_error", 0.0), 3),
+            150,
+        )
+        self._add_metric(
+            group,
+            "mean_ve_delta_pct",
+            _to_metric(_safe_get(section, "mean_ve_delta_pct", 0.0), 3),
+            180,
+        )
+
+        return group
+
+    def _add_metric(self, group, name, value, y):
+        label = Label()
+        label.Location = Point(10, y)
+        label.Size = Size(230, 24)
+        label.Text = "%s: %s" % (name, value)
+        group.Controls.Add(label)
+
+    def _on_export(self, sender, args):
+        self.action = "export"
+        self.DialogResult = DialogResult.OK
+        self.Close()
+
+    def _on_apply(self, sender, args):
+        self.action = "apply"
+        self.DialogResult = DialogResult.OK
+        self.Close()
+
+    def _on_open_folder(self, sender, args):
+        try:
+            Process.Start("explorer.exe", self.preview_dir)
+        except Exception as exc:
+            MessageBox.Show(
+                "Could not open folder:\n%s" % str(exc),
+                APP_TITLE_SHORT,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning,
+            )
+
+    def _on_cancel(self, sender, args):
+        self.action = "cancel"
+        self.DialogResult = DialogResult.Cancel
+        self.Close()
+
+
+def show_preview(summary, preview_dir):
+    dialog = PreviewDialog(summary, preview_dir)
+    dialog.ShowDialog()
+    return dialog.action
+
+
+def _copy_export_outputs(summary, summary_path, extra_files=None):
+    run_id = str(_safe_get(summary, "run_id") or "").replace("\\", "/").strip("/")
+    if not run_id:
+        raise RuntimeError("Summary missing run_id; cannot resolve export destination.")
+
+    dest_dir = Path.Combine(DEFAULT_REPO_ROOT, "runs")
+    for part in run_id.split("/"):
+        dest_dir = Path.Combine(dest_dir, part)
+    dest_dir = Path.Combine(dest_dir, "corrections")
+    Directory.CreateDirectory(dest_dir)
+
+    summary_dir = Path.GetDirectoryName(summary_path)
+    files_to_copy = [summary_path]
+    for side in ("front", "rear"):
+        section = _safe_get(summary, side)
+        if not section:
+            continue
+        csv_name = str(_safe_get(section, "csv", ""))
+        if not csv_name:
+            continue
+        files_to_copy.append(Path.Combine(summary_dir, csv_name))
+    pvv_name = str(_safe_get(summary, "pvv_patch", ""))
+    if pvv_name:
+        files_to_copy.append(Path.Combine(summary_dir, pvv_name))
+    if extra_files:
+        for extra in extra_files:
+            if extra:
+                files_to_copy.append(extra)
+
+    for src in files_to_copy:
+        if not src or not File.Exists(src):
+            raise RuntimeError("Expected output file missing: %s" % src)
+        dest = Path.Combine(dest_dir, Path.GetFileName(src))
+        File.Copy(src, dest, True)
+
+    return dest_dir
+
+
+class _ErrorViewForm(Form):
+    """Read-only scrollable error dialog so long channel lists stay visible."""
+
+    def __init__(self, body):
+        self.Text = APP_TITLE_SHORT + " (error)"
+        self.Size = Size(720, 460)
+        self.FormBorderStyle = FormBorderStyle.Sizable
+        self.StartPosition = FormStartPosition.CenterScreen
+        self.MinimizeBox = False
+        self.MaximizeBox = True
+
+        try:
+            from System.Windows.Forms import (
+                ScrollBars,
+                TextBox as _TextBox,
+                DockStyle,
+            )
+        except Exception:
+            from Windows.Forms import ScrollBars, TextBox as _TextBox, DockStyle
+
+        tb = _TextBox()
+        tb.Multiline = True
+        tb.ReadOnly = True
+        tb.ScrollBars = ScrollBars.Vertical
+        tb.WordWrap = True
+        tb.Dock = DockStyle.Fill
+        tb.Text = body
+        self.Controls.Add(tb)
+
+        btn_close = Button()
+        btn_close.Text = "Close"
+        btn_close.Dock = DockStyle.Bottom
+        btn_close.Height = 34
+        btn_close.Click += self._on_close
+        self.Controls.Add(btn_close)
+        self.AcceptButton = btn_close
+        self.CancelButton = btn_close
+
+    def _on_close(self, sender, args):
+        self.DialogResult = DialogResult.OK
+        self.Close()
+
+
+def _show_error_dialog(body):
+    try:
+        rendered = body.replace("\r\n", "\n").replace("\n", "\r\n")
+    except Exception:
+        rendered = body
+    try:
+        form = _ErrorViewForm(rendered)
+        form.ShowDialog()
+    except Exception:
+        # Fallback to a plain MessageBox if the custom form can't be built.
+        MessageBox.Show(
+            rendered,
+            APP_TITLE_SHORT,
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Error,
+        )
+
+
+def _show_cli_error(exit_code, stdout, stderr):
+    f1_error = _extract_f1_error(stderr)
+    body = "CLI failed (rc=%d)." % exit_code
+    if f1_error:
+        body += "\n\n%s" % f1_error
+    if stderr:
+        body += "\n\nstderr:\n%s" % stderr
+    if stdout:
+        body += "\n\nstdout:\n%s" % stdout
+    MessageBox.Show(
+        body,
+        APP_TITLE_SHORT + " (error)",
+        MessageBoxButtons.OK,
+        MessageBoxIcon.Error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TuneLab entrypoint
+# ---------------------------------------------------------------------------
+
+
+class DynoAIAutotune(ConfigurableChannelProvider):
+    def _perform_apply(self, summary, summary_path, temp_dir, file_handle):
+        mode = str(_safe_get(summary, "mode", MODE_DUAL))
+        if mode != MODE_DUAL:
+            raise RuntimeError(
+                "Apply is only supported in dual-cylinder mode. Current mode: %s" % mode
+            )
+
+        confirm = MessageBox.Show(
+            "Apply dual-cylinder corrections to the loaded tune?\r\n\r\n"
+            "A snapshot will be saved to runs/<run_id>/snapshots/ before writing.\r\n"
+            "Recommended: save a manual Power Core backup first (File -> Save As).",
+            APP_TITLE_SHORT,
+            MessageBoxButtons.YesNo,
+            MessageBoxIcon.Warning,
+        )
+        if confirm != DialogResult.Yes:
+            return None
+
+        grid = _safe_get(summary, "grid", {}) or {}
+        rpm_axis = _safe_get(grid, "rpm_axis", []) or []
+        map_axis = _safe_get(grid, "map_axis", []) or []
+        if not rpm_axis or not map_axis:
+            raise RuntimeError("Summary grid axes are missing; cannot apply.")
+
+        expected_rows = len(rpm_axis)
+        expected_cols = len(map_axis)
+        front_table, front_table_name, _ = _resolve_table_from_candidates(
+            VE_FRONT_TABLE_CANDIDATES, expected_rows, expected_cols
+        )
+        rear_table, rear_table_name, _ = _resolve_table_from_candidates(
+            VE_REAR_TABLE_CANDIDATES, expected_rows, expected_cols
+        )
+
+        front_grid, front_index_base = _extract_table_grid(
+            front_table, expected_rows, expected_cols
+        )
+        rear_grid, rear_index_base = _extract_table_grid(
+            rear_table, expected_rows, expected_cols
+        )
+
+        front_base_csv = Path.Combine(temp_dir, "VE_Front_Base.csv")
+        rear_base_csv = Path.Combine(temp_dir, "VE_Rear_Base.csv")
+        _write_ve_csv(front_base_csv, rpm_axis, map_axis, front_grid)
+        _write_ve_csv(rear_base_csv, rpm_axis, map_axis, rear_grid)
+
+        apply_args = [
+            "-m",
+            "tools.autotune.tunelab_entrypoint",
+            "apply",
+            "--run-id",
+            str(_safe_get(summary, "run_id", "")),
+            "--output-dir",
+            temp_dir,
+            "--base-front",
+            front_base_csv,
+            "--base-rear",
+            rear_base_csv,
+            "--mode",
+            MODE_DUAL,
+            "--max-adjust-pct",
+            str(APPLY_MAX_ADJUST_PCT),
+        ]
+        rc, stdout, stderr = run_cli(apply_args, timeout_seconds=APPLY_TIMEOUT_SECONDS)
+        if rc != 0:
+            _show_cli_error(rc, stdout, stderr)
+            return None
+
+        parsed_paths = _extract_apply_paths(stdout)
+        if not parsed_paths:
+            raise RuntimeError("Apply CLI output parse failed.\r\nstdout:\r\n%s" % stdout)
+        apply_front_csv, apply_rear_csv, session_log_path = parsed_paths
+        if not File.Exists(apply_front_csv) or not File.Exists(apply_rear_csv):
+            raise RuntimeError(
+                "Apply CLI succeeded but expected applied CSVs are missing.\r\n"
+                "front=%s\r\nrear=%s" % (apply_front_csv, apply_rear_csv)
+            )
+
+        front_rpm, front_map, front_applied_grid = _parse_ve_csv(apply_front_csv)
+        rear_rpm, rear_map, rear_applied_grid = _parse_ve_csv(apply_rear_csv)
+        if (
+            not _axes_match(rpm_axis, front_rpm)
+            or not _axes_match(map_axis, front_map)
+            or not _axes_match(rpm_axis, rear_rpm)
+            or not _axes_match(map_axis, rear_map)
+        ):
+            raise RuntimeError(
+                "Applied CSV axes do not match preview grid. "
+                "Check table shape compatibility before retrying."
+            )
+        if len(front_applied_grid) != expected_rows or len(rear_applied_grid) != expected_rows:
+            raise RuntimeError("Applied CSV row count mismatch with preview grid.")
+        if (
+            front_applied_grid
+            and len(front_applied_grid[0]) != expected_cols
+            or rear_applied_grid
+            and len(rear_applied_grid[0]) != expected_cols
+        ):
+            raise RuntimeError("Applied CSV column count mismatch with preview grid.")
+
+        _apply_grid_to_table(front_table, front_applied_grid, front_index_base)
+        _apply_grid_to_table(rear_table, rear_applied_grid, rear_index_base)
+        context.PutTable(front_table)  # noqa: F821
+        context.PutTable(rear_table)  # noqa: F821
+
+        audit_path = _append_apply_audit_log(
+            summary=summary,
+            file_desc=_describe_file_handle(file_handle),
+            front_table_name=front_table_name,
+            rear_table_name=rear_table_name,
+            session_log_path=session_log_path,
+        )
+
+        export_dir = _copy_export_outputs(
+            summary,
+            summary_path,
+            extra_files=[apply_front_csv, apply_rear_csv],
+        )
+        MessageBox.Show(
+            "Apply complete.\r\n\r\n"
+            "Updated tables:\r\n- %s\r\n- %s\r\n\r\n"
+            "session_log: %s\r\n"
+            "audit_log: %s\r\n"
+            "exports: %s\r\n\r\n"
+            "Review and flash using Power Core's native File menu."
+            % (
+                front_table_name,
+                rear_table_name,
+                session_log_path,
+                audit_path,
+                export_dir,
+            ),
+            APP_TITLE_SHORT,
+            MessageBoxButtons.OK,
+            MessageBoxIcon.Information,
+        )
+        return True
+
+    def _execute_preview_once(self):
+        have_files = False
+        temp_dir = None
+        try:
+            have_files = bool(context.EnsureFiles())  # noqa: F821
+        except Exception:
+            have_files = False
+
+        if not have_files:
+            MessageBox.Show(
+                "No log file loaded in Data Center.\n\nLoad a log first, then re-run autotune preview.",
+                APP_TITLE_SHORT,
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning,
+            )
+            return
+
+        try:
+            file_handles = list(channels.GetFileHandles())  # noqa: F821
+            if not file_handles:
+                MessageBox.Show(
+                    "No file handles available from TuneLab.",
+                    APP_TITLE_SHORT,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning,
+                )
+                return
+            file_handle = _select_best_file_handle(file_handles)
+            if file_handle is None:
+                MessageBox.Show(
+                    "No usable file handle found in Data Center.",
+                    APP_TITLE_SHORT,
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning,
+                )
+                return
+
+            run_id = _build_run_id(file_handle)
+            temp_dir = _create_temp_dir()
+            input_csv = Path.Combine(temp_dir, "tunelab_input.csv")
+            _row_count, detected_mode = _export_loaded_log_csv(file_handle, input_csv)
+
+            args = [
+                "-m",
+                "tools.autotune.tunelab_entrypoint",
+                "preview",
+                "--log-csv",
+                input_csv,
+                "--output-dir",
+                temp_dir,
+                "--run-id",
+                run_id,
+            ]
+            if detected_mode == "single_front":
+                args.extend(["--single-cylinder", "front"])
+            elif detected_mode == "single_rear":
+                args.extend(["--single-cylinder", "rear"])
+
+            rc, stdout, stderr = run_cli(args, timeout_seconds=CLI_TIMEOUT_SECONDS)
+            if rc != 0:
+                _show_cli_error(rc, stdout, stderr)
+                return
+
+            summary_path = _extract_summary_path(stdout)
+            if not summary_path or not File.Exists(summary_path):
+                MessageBox.Show(
+                    "CLI succeeded but summary path could not be parsed.\n\nstdout:\n%s"
+                    % stdout,
+                    APP_TITLE_SHORT + " (parse error)",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error,
+                )
+                return
+
+            summary = _load_summary(summary_path)
+            action = show_preview(summary, Path.GetDirectoryName(summary_path))
+            if action == "apply":
+                self._perform_apply(summary, summary_path, temp_dir, file_handle)
+                return
+            if action != "export":
+                return
+
+            export_dir = _copy_export_outputs(summary, summary_path)
+            msg = "Export complete.\n\nSaved files to:\n%s\n\nOpen folder now?" % export_dir
+            result = MessageBox.Show(
+                msg,
+                APP_TITLE_SHORT,
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Information,
+            )
+            if result == DialogResult.Yes:
+                try:
+                    Process.Start("explorer.exe", export_dir)
+                except Exception:
+                    pass
+
+        except Exception as exc:
+            _show_error_dialog("Autotune preview error:\n%s" % str(exc))
+        finally:
+            if have_files:
+                try:
+                    context.FreeFiles()  # noqa: F821
+                except Exception:
+                    pass
+            _safe_delete_dir(temp_dir)
+
+    def Run(self):
+        self._execute_preview_once()
+
+
+autotune = DynoAIAutotune()
+correction = autotune
+
+_autotune_executed = False
+
+
+def _execute_autotune_once():
+    global _autotune_executed
+    if _autotune_executed:
+        return
+    _autotune_executed = True
+    autotune.Run()
+
+
+def Run():
+    _execute_autotune_once()
+
+
+def PerformCorrection():
+    _execute_autotune_once()
+
+
+_execute_autotune_once()

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -6,23 +6,10 @@
 # mypy: ignore-errors
 
 try:
-    import json as _py_json
-except Exception:
-    _py_json = None
-
-import re
-import clr
-
-clr.AddReference("System")
-clr.AddReference("System.Windows.Forms")
-clr.AddReference("System.Drawing")
+import json as _py_json
 
 from System import DateTime, Environment, Guid
 from System.Diagnostics import Process, ProcessStartInfo
-try:
-    from System.Drawing import Color, Point, Size
-except Exception:
-    from Drawing import Color, Point, Size
 from System.IO import Directory, File, Path
 from System.Windows.Forms import (
     Button,
@@ -37,6 +24,24 @@ from System.Windows.Forms import (
     MessageBoxIcon,
 )
 from tunelab import ConfigurableChannelProvider
+
+except Exception:
+    _py_json = None
+
+import re
+
+import clr
+
+clr.AddReference("System")
+clr.AddReference("System.Windows.Forms")
+clr.AddReference("System.Drawing")
+
+
+try:
+    from System.Drawing import Color, Point, Size
+except Exception:
+    from Drawing import Color, Point, Size
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -257,7 +262,6 @@ DIAG_PROBE_NAMES = (
         "TQ",
     ]
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -529,7 +533,9 @@ def _estimate_map_from_rpm(rpm_value):
     return 80.0
 
 
-def _resolve_afr_or_voltage(file_handle, afr_aliases, volt_aliases, lambda_aliases=None):
+def _resolve_afr_or_voltage(
+    file_handle, afr_aliases, volt_aliases, lambda_aliases=None
+):
     """Resolve AFR input: prefer AFR-unit, fall back to voltage, then Lambda.
 
     Returns (channel, column_name). ``column_name`` is:
@@ -617,12 +623,13 @@ def _raise_channel_error(file_handle, missing, found_afr_f, found_afr_r):
 
     if ("AFR Front" in missing) or ("AFR Rear" in missing):
         raise RuntimeError(
-            "Cannot find any AFR channel in the loaded log." + nl
-            + "Missing: " + ", ".join(missing) + extra
+            "Cannot find any AFR channel in the loaded log."
+            + nl
+            + "Missing: "
+            + ", ".join(missing)
+            + extra
         )
-    raise RuntimeError(
-        "Missing required channels: " + ", ".join(missing) + extra
-    )
+    raise RuntimeError("Missing required channels: " + ", ".join(missing) + extra)
 
 
 def _channel_score(file_handle):
@@ -684,7 +691,9 @@ def _export_loaded_log_csv(file_handle, csv_path):
         missing.append("AFR Front")
         missing.append("AFR Rear")
     if missing:
-        _raise_channel_error(file_handle, missing, afr_f_ch is not None, afr_r_ch is not None)
+        _raise_channel_error(
+            file_handle, missing, afr_f_ch is not None, afr_r_ch is not None
+        )
 
     rpm_samples = _read_samples(rpm_ch)
     map_samples = _read_samples(map_ch)
@@ -1020,7 +1029,9 @@ def _extract_table_grid(table_obj, rows, cols):
             for r in range(rows):
                 row = []
                 for c in range(cols):
-                    row.append(_table_get_value(table_obj, r + base_index, c + base_index))
+                    row.append(
+                        _table_get_value(table_obj, r + base_index, c + base_index)
+                    )
                 grid.append(row)
             return grid, base_index
         except Exception as exc:
@@ -1137,7 +1148,9 @@ class PreviewDialog(Form):
         mode = str(_safe_get(self.summary, "mode", "dual_cylinder"))
         safety = _safe_get(self.summary, "safety", {}) or {}
         apply_blocked = bool(_safe_get(safety, "apply_blocked", False))
-        warn_threshold = float(_safe_get(safety, "warn_threshold_pct", WARN_THRESHOLD_PCT))
+        warn_threshold = float(
+            _safe_get(safety, "warn_threshold_pct", WARN_THRESHOLD_PCT)
+        )
         over_warn = bool(_safe_get(self.summary, "over_warn_threshold"))
         if apply_blocked and mode == MODE_DUAL:
             banner.Text = "APPLY BLOCKED: safety gates must pass before write-back."
@@ -1178,12 +1191,9 @@ class PreviewDialog(Form):
         footer = Label()
         footer.Location = Point(15, 315)
         footer.Size = Size(520, 40)
-        footer.Text = (
-            "run_id: %s\nsummary schema: v%s"
-            % (
-                _safe_get(self.summary, "run_id", "unknown"),
-                _safe_get(self.summary, "schema_version", "?"),
-            )
+        footer.Text = "run_id: %s\nsummary schema: v%s" % (
+            _safe_get(self.summary, "run_id", "unknown"),
+            _safe_get(self.summary, "schema_version", "?"),
         )
         self.Controls.Add(footer)
 
@@ -1257,7 +1267,9 @@ class PreviewDialog(Form):
             group.Controls.Add(na_label)
             return group
 
-        self._add_metric(group, "zones_adjusted", _safe_get(section, "zones_adjusted"), 30)
+        self._add_metric(
+            group, "zones_adjusted", _safe_get(section, "zones_adjusted"), 30
+        )
         self._add_metric(
             group,
             "max_correction_pct",
@@ -1270,7 +1282,9 @@ class PreviewDialog(Form):
             _to_metric(_safe_get(section, "min_pct", 0.0), 2),
             90,
         )
-        self._add_metric(group, "clipped_zones", _safe_get(section, "clipped_zones"), 120)
+        self._add_metric(
+            group, "clipped_zones", _safe_get(section, "clipped_zones"), 120
+        )
         self._add_metric(
             group,
             "mean_afr_error",
@@ -1377,12 +1391,13 @@ class _ErrorViewForm(Form):
 
         try:
             from System.Windows.Forms import (
-                ScrollBars,
-                TextBox as _TextBox,
                 DockStyle,
+                ScrollBars,
             )
+            from System.Windows.Forms import TextBox as _TextBox
         except Exception:
-            from Windows.Forms import ScrollBars, TextBox as _TextBox, DockStyle
+            from Windows.Forms import DockStyle, ScrollBars
+            from Windows.Forms import TextBox as _TextBox
 
         tb = _TextBox()
         tb.Multiline = True
@@ -1517,7 +1532,9 @@ class DynoAIAutotune(ConfigurableChannelProvider):
 
         parsed_paths = _extract_apply_paths(stdout)
         if not parsed_paths:
-            raise RuntimeError("Apply CLI output parse failed.\r\nstdout:\r\n%s" % stdout)
+            raise RuntimeError(
+                "Apply CLI output parse failed.\r\nstdout:\r\n%s" % stdout
+            )
         apply_front_csv, apply_rear_csv, session_log_path = parsed_paths
         if not File.Exists(apply_front_csv) or not File.Exists(apply_rear_csv):
             raise RuntimeError(
@@ -1537,7 +1554,10 @@ class DynoAIAutotune(ConfigurableChannelProvider):
                 "Applied CSV axes do not match preview grid. "
                 "Check table shape compatibility before retrying."
             )
-        if len(front_applied_grid) != expected_rows or len(rear_applied_grid) != expected_rows:
+        if (
+            len(front_applied_grid) != expected_rows
+            or len(rear_applied_grid) != expected_rows
+        ):
             raise RuntimeError("Applied CSV row count mismatch with preview grid.")
         if (
             front_applied_grid
@@ -1668,7 +1688,10 @@ class DynoAIAutotune(ConfigurableChannelProvider):
                 return
 
             export_dir = _copy_export_outputs(summary, summary_path)
-            msg = "Export complete.\n\nSaved files to:\n%s\n\nOpen folder now?" % export_dir
+            msg = (
+                "Export complete.\n\nSaved files to:\n%s\n\nOpen folder now?"
+                % export_dir
+            )
             result = MessageBox.Show(
                 msg,
                 APP_TITLE_SHORT,

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -4,29 +4,18 @@
 # IronPython 2.7 script loaded by Power Core TuneLab.
 # Preview/export only: no PutTable writes in this release.
 # mypy: ignore-errors
-
-try:
-import json as _py_json
-
-from System import DateTime, Environment, Guid
-from System.Diagnostics import Process, ProcessStartInfo
-from System.IO import Directory, File, Path
-from System.Windows.Forms import (
-    Button,
-    DialogResult,
-    Form,
-    FormBorderStyle,
-    FormStartPosition,
-    GroupBox,
-    Label,
-    MessageBox,
-    MessageBoxButtons,
-    MessageBoxIcon,
-)
-from tunelab import ConfigurableChannelProvider
-
-except Exception:
-    _py_json = None
+# fmt: off
+# isort: skip_file
+# autopep8: off
+#
+# IMPORTANT FOR AUTOFORMATTERS:
+# Do not reorder these imports. The CLR / System.* imports must follow
+# clr.AddReference(), and the optional-import fallbacks below are flat
+# top-level statements on purpose. A previous autoformat pass split a single
+# `try: ... except:` block across CLR imports and produced a P0 IndentationError
+# that prevented the script from loading inside Power Core. Keep the structure
+# below: each fallback is its own self-contained `try/except`, and the json
+# fallback uses a single-line guarded assignment that no formatter will break.
 
 import re
 
@@ -36,11 +25,63 @@ clr.AddReference("System")
 clr.AddReference("System.Windows.Forms")
 clr.AddReference("System.Drawing")
 
+# json: prefer stdlib, fall back to None on stripped IronPython distributions.
+# Single-line guarded form so isort/black/yapf cannot split a `try:` block.
+try: import json as _py_json  # noqa: E701,E401
+except Exception: _py_json = None  # noqa: E701,E722
+
+# CLR namespaces -- IronPython 2.7 sometimes exposes these without the System.
+# prefix on legacy Power Core builds, so each block is its own try/except.
+try:
+    from System import DateTime, Environment, Guid
+except Exception:
+    from DateTime import DateTime  # type: ignore[no-redef]
+    from Environment import Environment  # type: ignore[no-redef]
+    from Guid import Guid  # type: ignore[no-redef]
+
+try:
+    from System.Diagnostics import Process, ProcessStartInfo
+except Exception:
+    from Diagnostics import Process, ProcessStartInfo  # type: ignore[no-redef]
 
 try:
     from System.Drawing import Color, Point, Size
 except Exception:
-    from Drawing import Color, Point, Size
+    from Drawing import Color, Point, Size  # type: ignore[no-redef]
+
+try:
+    from System.IO import Directory, File, Path
+except Exception:
+    from IO import Directory, File, Path  # type: ignore[no-redef]
+
+try:
+    from System.Windows.Forms import (
+        Button,
+        DialogResult,
+        Form,
+        FormBorderStyle,
+        FormStartPosition,
+        GroupBox,
+        Label,
+        MessageBox,
+        MessageBoxButtons,
+        MessageBoxIcon,
+    )
+except Exception:
+    from Windows.Forms import (  # type: ignore[no-redef]
+        Button,
+        DialogResult,
+        Form,
+        FormBorderStyle,
+        FormStartPosition,
+        GroupBox,
+        Label,
+        MessageBox,
+        MessageBoxButtons,
+        MessageBoxIcon,
+    )
+
+from tunelab import ConfigurableChannelProvider
 
 
 # ---------------------------------------------------------------------------

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -12,6 +12,7 @@
 # (extreme correction / shape mismatch / partial cylinder / invalid base VE)
 # before any PutTable can run.
 # mypy: ignore-errors
+# ruff: noqa: E402,SIM105,UP031,UP034,UP015,B904
 # fmt: off
 # isort: skip_file
 # autopep8: off
@@ -109,7 +110,7 @@ MODE_SINGLE_FRONT = "single_cylinder_front"
 MODE_SINGLE_REAR = "single_cylinder_rear"
 MODE_CHOICES = (MODE_DUAL, MODE_SINGLE_FRONT, MODE_SINGLE_REAR)
 
-_RUN_SLUG_INVALID_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_RUN_SLUG_INVALID_RE = re.compile(r"[^A-Za-z0-9_-]+")
 
 
 def _safe_run_slug(run_id):
@@ -343,6 +344,7 @@ def _decode(data):
         if isinstance(data, unicode):
             return data
     except NameError:
+        # Python 3 runtime: ``unicode`` symbol is undefined by design.
         pass
     if isinstance(data, str):
         try:
@@ -393,6 +395,7 @@ def run_cli(args, timeout_seconds):
         try:
             proc.Kill()
         except Exception:
+            # Process can already be gone when timeout races with exit.
             pass
         return 124, _decode(raw_out), "[F1][ERR] cli_timeout"
 
@@ -546,6 +549,7 @@ def _safe_delete_dir(path_value):
         if Directory.Exists(path_value):
             Directory.Delete(path_value, True)
     except Exception:
+        # Temp cleanup is best-effort only.
         pass
 
 
@@ -880,6 +884,7 @@ def _dotnet_to_python(value):
         if isinstance(value, unicode):  # noqa: F821 - IronPython 2.7
             return value
     except NameError:
+        # Python 3 runtime: ``unicode`` symbol is undefined.
         pass
     if isinstance(value, str):
         return value
@@ -952,11 +957,13 @@ def _safe_get(mapping, key, default=None):
     try:
         return mapping.get(key, default)
     except AttributeError:
+        # .NET Dictionary types don't expose Python's dict.get.
         pass
     try:
         if mapping.ContainsKey(key):
             return mapping[key]
     except Exception:
+        # Mapping may be a plain dict without ContainsKey.
         pass
     try:
         return mapping[key]
@@ -1764,6 +1771,7 @@ class DynoAIAutotune(ConfigurableChannelProvider):
                 try:
                     Process.Start("explorer.exe", export_dir)
                 except Exception:
+                    # Opening Explorer is optional UX sugar.
                     pass
 
         except Exception as exc:
@@ -1773,6 +1781,7 @@ class DynoAIAutotune(ConfigurableChannelProvider):
                 try:
                     context.FreeFiles()  # noqa: F821
                 except Exception:
+                    # TuneLab file-handle release should not mask prior errors.
                     pass
             _safe_delete_dir(temp_dir)
 
@@ -1783,14 +1792,11 @@ class DynoAIAutotune(ConfigurableChannelProvider):
 autotune = DynoAIAutotune()
 correction = autotune
 
-_autotune_executed = False
-
 
 def _execute_autotune_once():
-    global _autotune_executed
-    if _autotune_executed:
+    if getattr(_execute_autotune_once, "_executed", False):
         return
-    _autotune_executed = True
+    _execute_autotune_once._executed = True
     autotune.Run()
 
 

--- a/api/services/integrations/powercore/dynoai_autotune.py
+++ b/api/services/integrations/powercore/dynoai_autotune.py
@@ -100,6 +100,38 @@ VE_FRONT_TABLE_NAME = "Volumetric Efficiency Front"
 VE_REAR_TABLE_NAME = "Volumetric Efficiency Rear"
 APPLY_MAX_ADJUST_PCT = 15.0
 
+# CLI <-> IronPython mode constants. Must mirror tools/autotune/tunelab_entrypoint.py.
+# Previously referenced as bare globals in `_perform_apply` without being defined,
+# producing NameError before the apply dialog could render.
+MODE_DUAL = "dual_cylinder"
+MODE_SINGLE_FRONT = "single_cylinder_front"
+MODE_SINGLE_REAR = "single_cylinder_rear"
+MODE_CHOICES = (MODE_DUAL, MODE_SINGLE_FRONT, MODE_SINGLE_REAR)
+
+
+_RUN_SLUG_INVALID_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_run_slug(run_id):
+    """Sanitize run_id to a filesystem-safe segment.
+
+    Mirrors tools.autotune.tunelab_entrypoint._safe_run_slug so a single
+    run_id sanitizer is applied on both sides of the CLI boundary. Strips
+    `..`, slashes, and any non [A-Za-z0-9._-] characters; collapses runs of
+    invalid characters into a single underscore. Returns "run" if the
+    result is empty so we never produce a zero-length path segment.
+    """
+    if run_id is None:
+        return "run"
+    text = str(run_id).strip()
+    if not text:
+        return "run"
+    slug = _RUN_SLUG_INVALID_RE.sub("_", text)
+    slug = slug.strip("_")
+    if not slug or slug in (".", ".."):
+        return "run"
+    return slug
+
 VE_FRONT_TABLE_CANDIDATES = [
     VE_FRONT_TABLE_NAME,
     "VE Front",

--- a/api/services/integrations/powercore/inspect_tunelab_context.py
+++ b/api/services/integrations/powercore/inspect_tunelab_context.py
@@ -8,7 +8,11 @@ import clr
 clr.AddReference("System")
 clr.AddReference("System.Windows.Forms")
 
-from System.Windows.Forms import MessageBox, MessageBoxButtons, MessageBoxIcon  # noqa: E402
+from System.Windows.Forms import (  # noqa: E402
+    MessageBox,
+    MessageBoxButtons,
+    MessageBoxIcon,
+)
 
 APP_TITLE = "DynoAI TuneLab Context Probe"
 VE_FRONT_TABLE_CANDIDATES = [
@@ -62,7 +66,9 @@ def Run():
     lines = []
     context_names = _safe_dir(context)  # noqa: F821
     lines.append("context attrs (%d):" % len(context_names))
-    lines.append(", ".join(context_names[:80]) + ("..." if len(context_names) > 80 else ""))
+    lines.append(
+        ", ".join(context_names[:80]) + ("..." if len(context_names) > 80 else "")
+    )
 
     try:
         tune_obj = context.tune  # noqa: F821
@@ -72,7 +78,9 @@ def Run():
         tune_names = _safe_dir(tune_obj)
         lines.append("")
         lines.append("tune attrs (%d):" % len(tune_names))
-        lines.append(", ".join(tune_names[:80]) + ("..." if len(tune_names) > 80 else ""))
+        lines.append(
+            ", ".join(tune_names[:80]) + ("..." if len(tune_names) > 80 else "")
+        )
 
     lines.append("")
     lines.append("Front table candidates:")

--- a/api/services/integrations/powercore/inspect_tunelab_context.py
+++ b/api/services/integrations/powercore/inspect_tunelab_context.py
@@ -1,0 +1,95 @@
+# mypy: ignore-errors
+
+# Inspect TuneLab context/table APIs in-place.
+# Throwaway diagnostic helper for F1.1 table-name verification.
+
+import clr
+
+clr.AddReference("System")
+clr.AddReference("System.Windows.Forms")
+
+from System.Windows.Forms import MessageBox, MessageBoxButtons, MessageBoxIcon  # noqa: E402
+
+APP_TITLE = "DynoAI TuneLab Context Probe"
+VE_FRONT_TABLE_CANDIDATES = [
+    "Volumetric Efficiency Front",
+    "VE Front",
+    "Volumetric Efficiency - Front",
+    "Volumetric Efficiency Front Cylinder",
+]
+VE_REAR_TABLE_CANDIDATES = [
+    "Volumetric Efficiency Rear",
+    "VE Rear",
+    "Volumetric Efficiency - Rear",
+    "Volumetric Efficiency Rear Cylinder",
+]
+
+
+def _safe_dir(obj):
+    try:
+        names = [str(x) for x in dir(obj)]
+        names.sort()
+        return names
+    except Exception:
+        return []
+
+
+def _probe_table(name):
+    try:
+        table = context.GetTable(name)  # noqa: F821
+    except Exception as exc:
+        return "%s -> ERROR: %s" % (name, str(exc))
+    if table is None:
+        return "%s -> None" % name
+
+    api_names = _safe_dir(table)
+    preview = ", ".join(api_names[:30]) + ("..." if len(api_names) > 30 else "")
+    sample = None
+    for row_idx, col_idx in ((0, 0), (1, 1)):
+        try:
+            sample = table.GetValue(row_idx, col_idx)
+            break
+        except Exception:
+            try:
+                sample = table[row_idx, col_idx]
+                break
+            except Exception:
+                continue
+    return "%s -> OK (sample=%s) APIs: %s" % (name, str(sample), preview)
+
+
+def Run():
+    lines = []
+    context_names = _safe_dir(context)  # noqa: F821
+    lines.append("context attrs (%d):" % len(context_names))
+    lines.append(", ".join(context_names[:80]) + ("..." if len(context_names) > 80 else ""))
+
+    try:
+        tune_obj = context.tune  # noqa: F821
+    except Exception:
+        tune_obj = None
+    if tune_obj is not None:
+        tune_names = _safe_dir(tune_obj)
+        lines.append("")
+        lines.append("tune attrs (%d):" % len(tune_names))
+        lines.append(", ".join(tune_names[:80]) + ("..." if len(tune_names) > 80 else ""))
+
+    lines.append("")
+    lines.append("Front table candidates:")
+    for name in VE_FRONT_TABLE_CANDIDATES:
+        lines.append(_probe_table(name))
+
+    lines.append("")
+    lines.append("Rear table candidates:")
+    for name in VE_REAR_TABLE_CANDIDATES:
+        lines.append(_probe_table(name))
+
+    MessageBox.Show(
+        "\r\n".join(lines),
+        APP_TITLE,
+        MessageBoxButtons.OK,
+        MessageBoxIcon.Information,
+    )
+
+
+Run()

--- a/api/services/jetdrive/jetdrive_realtime_analysis.py
+++ b/api/services/jetdrive/jetdrive_realtime_analysis.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from dynoai.core.kernel_sentinel import KernelSentinel, KernelSentinelConfig
+
 logger = logging.getLogger(__name__)
 
 # =============================================================================
@@ -46,6 +48,8 @@ FROZEN_TPS_THRESHOLD = 20.0  # Only alert if TPS > this (engine running)
 AFR_MIN_PLAUSIBLE = 10.0
 AFR_MAX_PLAUSIBLE = 18.0
 CHANNEL_STALE_THRESHOLD_SEC = 5.0  # Channel not updated for this long = stale
+INJECTOR_DUTY_WARN_PCT = 80.0
+INJECTOR_DUTY_HALT_PCT = 85.0
 
 # Quality weights
 QUALITY_WEIGHT_FRESHNESS = 0.4
@@ -72,6 +76,8 @@ class AlertType(str, Enum):
     MISSING_CHANNEL = "missing_channel"
     STALE_CHANNEL = "stale_channel"
     OUT_OF_RANGE = "out_of_range"
+    INJECTOR_DUTY_HIGH = "injector_duty_high"
+    KERNEL_SENTINEL = "kernel_sentinel"
 
 
 class AlertSeverity(str, Enum):
@@ -297,6 +303,12 @@ class RealtimeAnalysisEngine:
             target_afr: Target AFR for VE delta calculation (default stoich)
         """
         self.target_afr = target_afr
+        self.kernel_sentinel = KernelSentinel(
+            KernelSentinelConfig(
+                lambda_targets=KernelSentinelConfig().lambda_targets,
+                halt_on_breach=True,
+            )
+        )
 
         # Coverage map: (rpm_bin, map_bin) -> CoverageCell
         self.coverage_map: dict[tuple[int, int], CoverageCell] = {}
@@ -314,6 +326,7 @@ class RealtimeAnalysisEngine:
         self._last_rpm: float | None = None
         self._last_rpm_time: float = 0.0
         self._last_tps: float = 0.0
+        self._last_injector_duty_pct: float | None = None
         self._active_cell: tuple[int, int] | None = None
 
         # Thread safety
@@ -321,6 +334,13 @@ class RealtimeAnalysisEngine:
 
         # Start time for relative timestamps
         self._start_time = time.time()
+
+    def set_kernel_sentinel_config(self, payload: dict[str, Any] | None) -> None:
+        """Replace live sentinel config without resetting coverage state."""
+        with self._lock:
+            self.kernel_sentinel = KernelSentinel(
+                KernelSentinelConfig.from_dict(payload)
+            )
 
     def on_aggregated_sample(self, data: dict[str, Any]) -> None:
         """
@@ -340,15 +360,20 @@ class RealtimeAnalysisEngine:
             map_kpa = data.get("map_kpa")
             afr = data.get("afr")
             tps = data.get("tps")
+            injector_duty_pct = self._compute_injector_duty_pct(rpm, data)
+            if injector_duty_pct is not None:
+                self._last_injector_duty_pct = injector_duty_pct
 
             # Update quality metrics for all present channels
-            self._update_quality(data, current_time)
+            self._update_quality(data, current_time, injector_duty_pct=injector_duty_pct)
 
             # Check for missing required channels
             self._check_missing_channels(data)
 
             # Detect alerts
-            self._detect_alerts(data, current_time)
+            self._detect_alerts(
+                data, current_time, injector_duty_pct=injector_duty_pct
+            )
 
             # Update coverage and VE delta if we have required data
             if rpm is not None and rpm > 0:
@@ -421,7 +446,12 @@ class RealtimeAnalysisEngine:
         afr_error = afr - self.target_afr
         self.ve_delta_map[bin_key].update(afr_error)
 
-    def _update_quality(self, data: dict[str, Any], current_time: float) -> None:
+    def _update_quality(
+        self,
+        data: dict[str, Any],
+        current_time: float,
+        injector_duty_pct: float | None = None,
+    ) -> None:
         """Update quality metrics for all present channels. O(n) where n = channels."""
         channel_map = {
             "rpm": data.get("rpm"),
@@ -430,6 +460,7 @@ class RealtimeAnalysisEngine:
             "tps": data.get("tps"),
             "torque": data.get("torque"),
             "horsepower": data.get("horsepower"),
+            "injector_duty_pct": injector_duty_pct,
         }
 
         for channel, value in channel_map.items():
@@ -446,7 +477,12 @@ class RealtimeAnalysisEngine:
 
         self.quality.missing_channels = missing
 
-    def _detect_alerts(self, data: dict[str, Any], current_time: float) -> None:
+    def _detect_alerts(
+        self,
+        data: dict[str, Any],
+        current_time: float,
+        injector_duty_pct: float | None = None,
+    ) -> None:
         """Detect and emit alerts. O(1)."""
         rpm = data.get("rpm")
         afr = data.get("afr")
@@ -518,6 +554,58 @@ class RealtimeAnalysisEngine:
                         timestamp=current_time,
                     )
                 )
+
+        # Injector duty risk flag (HIGH if >85%)
+        if injector_duty_pct is not None:
+            if injector_duty_pct > INJECTOR_DUTY_HALT_PCT:
+                self._add_alert(
+                    Alert(
+                        type=AlertType.INJECTOR_DUTY_HIGH,
+                        severity=AlertSeverity.CRITICAL,
+                        channel="injector_duty_pct",
+                        message=(
+                            f"Injector duty {injector_duty_pct:.1f}% exceeds "
+                            f"halt threshold {INJECTOR_DUTY_HALT_PCT:.1f}%"
+                        ),
+                        timestamp=current_time,
+                        value=injector_duty_pct,
+                    )
+                )
+            elif injector_duty_pct > INJECTOR_DUTY_WARN_PCT:
+                self._add_alert(
+                    Alert(
+                        type=AlertType.INJECTOR_DUTY_HIGH,
+                        severity=AlertSeverity.WARNING,
+                        channel="injector_duty_pct",
+                        message=(
+                            f"Injector duty {injector_duty_pct:.1f}% exceeds "
+                            f"warning threshold {INJECTOR_DUTY_WARN_PCT:.1f}%"
+                        ),
+                        timestamp=current_time,
+                        value=injector_duty_pct,
+                    )
+                )
+
+        afr_error = None
+        if afr is not None and not math.isnan(afr):
+            afr_error = afr - self.target_afr
+
+        for breach in self.kernel_sentinel.evaluate_realtime_sample(
+            data, afr_error=afr_error
+        ):
+            self._add_alert(
+                Alert(
+                    type=AlertType.KERNEL_SENTINEL,
+                    severity=(
+                        AlertSeverity.CRITICAL
+                        if breach.severity.value == "critical"
+                        else AlertSeverity.WARNING
+                    ),
+                    channel="kernel_sentinel",
+                    message=breach.message,
+                    timestamp=current_time,
+                )
+            )
 
     def _add_alert(self, alert: Alert) -> None:
         """Add alert to queue, avoiding duplicates. O(n) where n = MAX_ALERTS."""
@@ -593,6 +681,11 @@ class RealtimeAnalysisEngine:
                 "ve_delta": ve_delta,
                 "quality": quality,
                 "alerts": alerts,
+                "injector_duty_pct": (
+                    round(self._last_injector_duty_pct, 2)
+                    if self._last_injector_duty_pct is not None
+                    else None
+                ),
                 "uptime_sec": round(current_time - self._start_time, 1),
             }
 
@@ -606,8 +699,44 @@ class RealtimeAnalysisEngine:
             self._last_rpm = None
             self._last_rpm_time = 0.0
             self._last_tps = 0.0
+            self._last_injector_duty_pct = None
             self._active_cell = None
             self._start_time = time.time()
+
+    @staticmethod
+    def _compute_injector_duty_pct(
+        rpm: float | None, data: dict[str, Any]
+    ) -> float | None:
+        """
+        Compute injector duty cycle percentage from pulse width and RPM.
+
+        Formula (4-stroke): duty_pct = pulsewidth_ms * rpm / 1200
+        Equivalent to the project formula with percent scaling:
+        pulsewidth_ms * rpm / 60 / 1000 * 2 * 100
+        """
+        if rpm is None:
+            return None
+        try:
+            rpm_f = float(rpm)
+        except (TypeError, ValueError):
+            return None
+        if rpm_f <= 0:
+            return None
+
+        pulse_width = data.get("injector_pulsewidth_ms")
+        if pulse_width is None:
+            pulse_width = data.get("inj_pw_ms")
+        if pulse_width is None:
+            pulse_width = data.get("pw_ms")
+        if pulse_width is None:
+            return None
+        try:
+            pw_ms = float(pulse_width)
+        except (TypeError, ValueError):
+            return None
+        if pw_ms <= 0:
+            return None
+        return (pw_ms * rpm_f) / 1200.0
 
 
 # =============================================================================

--- a/api/services/jetdrive/jetdrive_realtime_analysis.py
+++ b/api/services/jetdrive/jetdrive_realtime_analysis.py
@@ -365,15 +365,15 @@ class RealtimeAnalysisEngine:
                 self._last_injector_duty_pct = injector_duty_pct
 
             # Update quality metrics for all present channels
-            self._update_quality(data, current_time, injector_duty_pct=injector_duty_pct)
+            self._update_quality(
+                data, current_time, injector_duty_pct=injector_duty_pct
+            )
 
             # Check for missing required channels
             self._check_missing_channels(data)
 
             # Detect alerts
-            self._detect_alerts(
-                data, current_time, injector_duty_pct=injector_duty_pct
-            )
+            self._detect_alerts(data, current_time, injector_duty_pct=injector_duty_pct)
 
             # Update coverage and VE delta if we have required data
             if rpm is not None and rpm > 0:

--- a/api/services/jetdrive/wideband_rescale.py
+++ b/api/services/jetdrive/wideband_rescale.py
@@ -168,24 +168,20 @@ def match_wideband_channel(name: str) -> Optional[str]:
 
     is_innovate_canonical = "petrol" in lowered and "afr" in lowered
     is_lc_short_form = (
-        ("lc1" in lowered or "lc2" in lowered or "lc-1" in lowered or "lc-2" in lowered)
-        and "afr" in lowered
-    )
-    is_wb_marker = (
-        "wbo2" in lowered or "wideband" in lowered or "innovate" in lowered
-    )
+        "lc1" in lowered or "lc2" in lowered or "lc-1" in lowered or "lc-2" in lowered
+    ) and "afr" in lowered
+    is_wb_marker = "wbo2" in lowered or "wideband" in lowered or "innovate" in lowered
     is_afr_volts_form = (
-        ("afr volts " in f"{lowered} " or " volts afr" in f" {lowered}")
-        and (
-            "1" in lowered
-            or "2" in lowered
-            or " f " in f" {lowered} "
-            or " r " in f" {lowered} "
-            or "front" in lowered
-            or "rear" in lowered
-            or lowered.endswith(" f")
-            or lowered.endswith(" r")
-        )
+        "afr volts " in f"{lowered} " or " volts afr" in f" {lowered}"
+    ) and (
+        "1" in lowered
+        or "2" in lowered
+        or " f " in f" {lowered} "
+        or " r " in f" {lowered} "
+        or "front" in lowered
+        or "rear" in lowered
+        or lowered.endswith(" f")
+        or lowered.endswith(" r")
     )
     if not (
         is_innovate_canonical or is_lc_short_form or is_wb_marker or is_afr_volts_form

--- a/api/services/jetdrive/wideband_rescale.py
+++ b/api/services/jetdrive/wideband_rescale.py
@@ -137,26 +137,83 @@ def match_wideband_channel(name: str) -> Optional[str]:
     """Detect a DynoWare channel that carries LC-1/LC-2 voltage.
 
     Returns the canonical target slot (e.g. "AFR Front", "AFR Rear", or
-    plain "AFR") when the name matches the documented LC voltage channel
-    naming; returns None otherwise.
+    plain "AFR") when the name matches a known LC voltage channel naming;
+    returns None otherwise.
 
-    Name matching is deliberately conservative: all three tokens
-    ("volts", "petrol", "afr") must appear for a match. This mirrors the
-    prior frontend heuristic but now lives server-side as the single
-    source of truth. Rigs with non-standard channel naming should
-    configure an override via the admin/config surface rather than
-    relying on pattern matching.
+    Recognized forms (case-insensitive, in priority order):
+
+    1. The Innovate-canonical "LC2 Volts Petrol AFR1/2" / "LC1 Volts ...".
+       Identified by all three tokens ("volts", "petrol", "afr").
+    2. "LC1 Volts AFR1" / "LC2 Volts AFR1/2" forms exported by some
+       Power Core / DynoWare configurations that drop "petrol".
+       Identified by "lc" + a digit + "volts" + "afr".
+    3. "WBO2 F Volts" / "Wideband Volts 1/F" / "Innovate Volts F" /
+       "AFR Volts F/1". Identified by "volts" plus a wideband marker
+       ("wbo2", "wideband", "innovate") or "afr volts" / "volts afr"
+       with a cylinder hint.
+
+    Front vs rear is decided by the cylinder/index hint ("1" / "front" /
+    "f" -> front; "2" / "rear" / "r" -> rear). When no hint is present
+    the canonical slot is plain "AFR".
+
+    Rigs with non-standard naming that this still misses should configure
+    an explicit alias mapping rather than relying on pattern matching.
     """
     if not isinstance(name, str) or not name:
         return None
 
     lowered = name.lower()
-    if not ("volts" in lowered and "petrol" in lowered and "afr" in lowered):
+    if "volts" not in lowered:
         return None
 
-    if "1" in lowered or "front" in lowered:
+    is_innovate_canonical = "petrol" in lowered and "afr" in lowered
+    is_lc_short_form = (
+        ("lc1" in lowered or "lc2" in lowered or "lc-1" in lowered or "lc-2" in lowered)
+        and "afr" in lowered
+    )
+    is_wb_marker = (
+        "wbo2" in lowered or "wideband" in lowered or "innovate" in lowered
+    )
+    is_afr_volts_form = (
+        ("afr volts " in f"{lowered} " or " volts afr" in f" {lowered}")
+        and (
+            "1" in lowered
+            or "2" in lowered
+            or " f " in f" {lowered} "
+            or " r " in f" {lowered} "
+            or "front" in lowered
+            or "rear" in lowered
+            or lowered.endswith(" f")
+            or lowered.endswith(" r")
+        )
+    )
+    if not (
+        is_innovate_canonical or is_lc_short_form or is_wb_marker or is_afr_volts_form
+    ):
+        return None
+
+    has_front_hint = (
+        "front" in lowered
+        or "afr1" in lowered
+        or "afr 1" in lowered
+        or " f " in f" {lowered} "
+        or lowered.endswith(" f")
+        or "volts 1" in lowered
+        or " 1 " in f" {lowered} "
+    )
+    has_rear_hint = (
+        "rear" in lowered
+        or "afr2" in lowered
+        or "afr 2" in lowered
+        or " r " in f" {lowered} "
+        or lowered.endswith(" r")
+        or "volts 2" in lowered
+        or " 2 " in f" {lowered} "
+    )
+
+    if has_front_hint and not has_rear_hint:
         return "AFR Front"
-    if "2" in lowered or "rear" in lowered:
+    if has_rear_hint and not has_front_hint:
         return "AFR Rear"
     return "AFR"
 

--- a/api/services/sessions/__init__.py
+++ b/api/services/sessions/__init__.py
@@ -1,0 +1,9 @@
+"""Session-level services for DynoAI workspace.
+
+This package houses the v3 session schema (`session_v3.py`) and the
+session-execution coordinators (phased pull controller, dispatch readiness
+evaluator, P0 plausibility checker) that consume it.
+
+The v3 schema is layered on top of the existing `TuningSession` dataclass in
+`api/services/tuning_workspace.py`; legacy v0 sessions remain readable.
+"""

--- a/api/services/sessions/dispatch_readiness.py
+++ b/api/services/sessions/dispatch_readiness.py
@@ -1,0 +1,95 @@
+"""Dispatch readiness evaluator for `dynoai.session.v3` sessions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.services.tuning_workspace import SessionStatus, TuningSession
+
+
+def evaluate_dispatch_readiness(
+    session: TuningSession,
+    workspace_status: SessionStatus,
+) -> dict[str, Any]:
+    """
+    Aggregate dispatch gates for a v3 session.
+
+    Gates:
+    - Workspace has required artifacts (base tune + pulls)
+    - All blocking verify blockers are resolved
+    - Session status has reached a template `dispatch_after` state (if configured)
+    - Kernel sentinel has `halt_on_breach` explicitly enabled
+    - P0 plausibility has a pass/warn outcome recorded
+    """
+    v3 = session.v3 or {}
+    template = v3.get("template") or {}
+    kernel = v3.get("kernel_sentinel") or {}
+    blockers = v3.get("verify_blockers") or []
+    session_blockers = v3.get("session_blockers") or []
+
+    unresolved_verify = []
+    for blocker in blockers:
+        if not isinstance(blocker, dict):
+            continue
+        if not blocker.get("blocking", True):
+            continue
+        if not blocker.get("resolved", False):
+            unresolved_verify.append(
+                {
+                    "field": blocker.get("field"),
+                    "owner": blocker.get("owner"),
+                }
+            )
+
+    dispatch_after = template.get("dispatch_after") or []
+    status_gate_ok = True
+    if isinstance(dispatch_after, list) and dispatch_after:
+        status_gate_ok = session.status in dispatch_after
+
+    halt_on_breach = bool(kernel.get("halt_on_breach"))
+    p0 = _extract_p0_status(v3)
+    p0_ok = p0 in {"pass", "warn", "warning"}
+
+    ready = all(
+        [
+            workspace_status.ready_to_analyze,
+            not unresolved_verify,
+            not session_blockers,
+            status_gate_ok,
+            halt_on_breach,
+            p0_ok,
+        ]
+    )
+
+    return {
+        "ready": ready,
+        "session_id": session.id,
+        "schema_version": session.schema_version,
+        "gates": {
+            "workspace_ready": workspace_status.ready_to_analyze,
+            "verify_blockers_resolved": len(unresolved_verify) == 0,
+            "session_blockers_clear": len(session_blockers) == 0,
+            "status_gate_ok": status_gate_ok,
+            "kernel_halt_on_breach": halt_on_breach,
+            "p0_plausibility_ok": p0_ok,
+        },
+        "details": {
+            "unresolved_verify_blockers": unresolved_verify,
+            "session_blockers": session_blockers,
+            "dispatch_after": dispatch_after,
+            "current_status": session.status,
+            "p0_plausibility_status": p0,
+            "workspace_status": workspace_status.to_dict(),
+        },
+    }
+
+
+def _extract_p0_status(v3: dict[str, Any]) -> str | None:
+    checks = v3.get("checks")
+    if isinstance(checks, dict):
+        p0 = checks.get("p0_plausibility")
+        if isinstance(p0, dict):
+            status = p0.get("status")
+            if isinstance(status, str):
+                return status.lower()
+    return None

--- a/api/services/sessions/p0_plausibility_checker.py
+++ b/api/services/sessions/p0_plausibility_checker.py
@@ -1,0 +1,124 @@
+"""P0 plausibility checks against known displacement and dyno telemetry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class PlausibilityResult:
+    status: str
+    score: int
+    checks: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "score": self.score,
+            "checks": self.checks,
+        }
+
+
+def evaluate_p0_plausibility(
+    *,
+    known_displacement_ci: float,
+    measured_displacement_ci: float | None = None,
+    peak_tq_ftlb: float | None = None,
+    peak_tq_rpm: float | None = None,
+    bmep_psi: float | None = None,
+    bsfc_lb_hp_hr: float | None = None,
+) -> PlausibilityResult:
+    """
+    Run conservative P0 plausibility checks.
+
+    Includes:
+    - displacement consistency versus known platform value
+    - BMEP plausibility band check
+    - peak-torque RPM band sanity
+    - BSFC plausibility sanity
+    """
+    checks: list[dict[str, Any]] = []
+    score = 100
+
+    if measured_displacement_ci is not None:
+        delta = abs(float(measured_displacement_ci) - float(known_displacement_ci))
+        ok = delta <= 8.0
+        if not ok:
+            score -= 20
+        checks.append(
+            {
+                "id": "displacement_consistency",
+                "ok": ok,
+                "detail": {
+                    "known_ci": known_displacement_ci,
+                    "measured_ci": measured_displacement_ci,
+                    "delta_ci": round(delta, 2),
+                },
+            }
+        )
+
+    derived_bmep = None
+    if peak_tq_ftlb is not None:
+        derived_bmep = _compute_bmep_psi(float(peak_tq_ftlb), float(known_displacement_ci))
+        checks.append(
+            {
+                "id": "bmep_derived",
+                "ok": 70.0 <= derived_bmep <= 220.0,
+                "detail": {
+                    "peak_tq_ftlb": peak_tq_ftlb,
+                    "derived_bmep_psi": round(derived_bmep, 2),
+                },
+            }
+        )
+        if not (70.0 <= derived_bmep <= 220.0):
+            score -= 25
+
+    if bmep_psi is not None:
+        bmep_ok = 70.0 <= float(bmep_psi) <= 220.0
+        checks.append(
+            {
+                "id": "bmep_input_band",
+                "ok": bmep_ok,
+                "detail": {"bmep_psi": bmep_psi},
+            }
+        )
+        if not bmep_ok:
+            score -= 20
+
+    if peak_tq_rpm is not None:
+        rpm_ok = 2500.0 <= float(peak_tq_rpm) <= 4500.0
+        checks.append(
+            {
+                "id": "peak_tq_rpm_band",
+                "ok": rpm_ok,
+                "detail": {"peak_tq_rpm": peak_tq_rpm, "expected_band": [2500, 4500]},
+            }
+        )
+        if not rpm_ok:
+            score -= 15
+
+    if bsfc_lb_hp_hr is not None:
+        bsfc_ok = 0.35 <= float(bsfc_lb_hp_hr) <= 0.75
+        checks.append(
+            {
+                "id": "bsfc_band",
+                "ok": bsfc_ok,
+                "detail": {"bsfc_lb_hp_hr": bsfc_lb_hp_hr, "expected_band": [0.35, 0.75]},
+            }
+        )
+        if not bsfc_ok:
+            score -= 15
+
+    if score >= 85:
+        status = "pass"
+    elif score >= 65:
+        status = "warn"
+    else:
+        status = "fail"
+    return PlausibilityResult(status=status, score=score, checks=checks)
+
+
+def _compute_bmep_psi(torque_ftlb: float, displacement_ci: float) -> float:
+    # 4-stroke approximation in psi.
+    return (150.8 * torque_ftlb) / displacement_ci

--- a/api/services/sessions/p0_plausibility_checker.py
+++ b/api/services/sessions/p0_plausibility_checker.py
@@ -60,7 +60,9 @@ def evaluate_p0_plausibility(
 
     derived_bmep = None
     if peak_tq_ftlb is not None:
-        derived_bmep = _compute_bmep_psi(float(peak_tq_ftlb), float(known_displacement_ci))
+        derived_bmep = _compute_bmep_psi(
+            float(peak_tq_ftlb), float(known_displacement_ci)
+        )
         checks.append(
             {
                 "id": "bmep_derived",
@@ -104,7 +106,10 @@ def evaluate_p0_plausibility(
             {
                 "id": "bsfc_band",
                 "ok": bsfc_ok,
-                "detail": {"bsfc_lb_hp_hr": bsfc_lb_hp_hr, "expected_band": [0.35, 0.75]},
+                "detail": {
+                    "bsfc_lb_hp_hr": bsfc_lb_hp_hr,
+                    "expected_band": [0.35, 0.75],
+                },
             }
         )
         if not bsfc_ok:

--- a/api/services/sessions/phased_pull_controller.py
+++ b/api/services/sessions/phased_pull_controller.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-
 DEFAULT_PHASE_ORDER = ["P0", "P1", "P2", "P3", "P4"]
 
 

--- a/api/services/sessions/phased_pull_controller.py
+++ b/api/services/sessions/phased_pull_controller.py
@@ -1,0 +1,99 @@
+"""P0..P4 phased pull controller for v3 session execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+DEFAULT_PHASE_ORDER = ["P0", "P1", "P2", "P3", "P4"]
+
+
+@dataclass
+class PhaseSnapshot:
+    active_phase: str
+    completed_phases: list[str]
+    remaining_phases: list[str]
+    can_advance: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "active_phase": self.active_phase,
+            "completed_phases": self.completed_phases,
+            "remaining_phases": self.remaining_phases,
+            "can_advance": self.can_advance,
+        }
+
+
+def derive_phase_order(v3_payload: dict[str, Any] | None) -> list[str]:
+    if not v3_payload:
+        return list(DEFAULT_PHASE_ORDER)
+
+    adaptive = v3_payload.get("adaptive_test_plan")
+    if not isinstance(adaptive, dict):
+        return list(DEFAULT_PHASE_ORDER)
+    phases = adaptive.get("phases")
+    if not isinstance(phases, list):
+        return list(DEFAULT_PHASE_ORDER)
+
+    order: list[str] = []
+    for phase in phases:
+        if not isinstance(phase, dict):
+            continue
+        phase_id = str(phase.get("id") or "").strip().upper()
+        if not phase_id:
+            continue
+        order.append(phase_id)
+    return order or list(DEFAULT_PHASE_ORDER)
+
+
+def compute_phase_snapshot(v3_payload: dict[str, Any] | None) -> PhaseSnapshot:
+    order = derive_phase_order(v3_payload)
+    execution = (v3_payload or {}).get("execution") if v3_payload else {}
+    if not isinstance(execution, dict):
+        execution = {}
+
+    completed = execution.get("completed_phases")
+    if not isinstance(completed, list):
+        completed = []
+    completed_norm = [str(p).upper() for p in completed if str(p).strip()]
+
+    active = execution.get("active_phase")
+    active_norm = str(active).upper() if active else None
+    if active_norm not in order:
+        active_norm = _first_remaining(order, completed_norm) or order[-1]
+
+    remaining = [p for p in order if p not in completed_norm]
+    can_advance = bool(remaining and active_norm in remaining)
+    return PhaseSnapshot(
+        active_phase=active_norm,
+        completed_phases=completed_norm,
+        remaining_phases=remaining,
+        can_advance=can_advance,
+    )
+
+
+def mark_phase_complete(
+    v3_payload: dict[str, Any],
+    phase_id: str,
+) -> dict[str, Any]:
+    order = derive_phase_order(v3_payload)
+    phase = phase_id.strip().upper()
+    if phase not in order:
+        raise ValueError(f"unknown phase: {phase_id}")
+
+    execution = v3_payload.setdefault("execution", {})
+    completed = execution.setdefault("completed_phases", [])
+    if phase not in completed:
+        completed.append(phase)
+
+    next_phase = _first_remaining(order, [str(p).upper() for p in completed])
+    execution["active_phase"] = next_phase or phase
+    return v3_payload
+
+
+def _first_remaining(order: list[str], completed: list[str]) -> str | None:
+    for phase in order:
+        if phase not in completed:
+            return phase
+    return None

--- a/api/services/sessions/session_v3.py
+++ b/api/services/sessions/session_v3.py
@@ -1,0 +1,308 @@
+"""
+Pydantic models for `dynoai.session.v3` workspace session blueprints.
+
+The legacy `TuningSession` dataclass in `api/services/tuning_workspace.py`
+remains the storage anchor; this module validates and normalizes the richer
+v3 payload stored under `TuningSession.v3`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SCHEMA_VERSION = "dynoai.session.v3"
+
+
+class VerifiedValue(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    value: Any
+    verified: Literal[True] = True
+    source: str = ""
+    evidence: str = ""
+
+
+class InferredValue(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    value: Any
+    inferred: Literal[True] = True
+    source: str = ""
+    confidence: str = ""
+    kill_switch: str = ""
+
+
+class Customer(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: Optional[str] = None
+    lead_status: Optional[str] = None
+    intake_call_scheduled: Optional[str] = None
+    intake_call_completed: Optional[str] = None
+    notion_page_id: Optional[str] = None
+
+
+class SessionVehicle(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    year: Optional[int] = None
+    make: Optional[str] = None
+    model: Optional[str] = None
+    common_name: Optional[str] = None
+    vin: Optional[str] = None
+    mileage_last_known: Optional[int] = None
+    mileage_date: Optional[str] = None
+    platform: Optional[str] = None
+    counterbalanced: Optional[bool] = None
+
+
+class CamSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    kit_pn: Optional[str] = None
+    type: Optional[str] = None
+    profile: Optional[str] = None
+
+
+class InjectorSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    flow_rate_g_s: Optional[float] = None
+    stock_flow_g_s: Optional[float] = None
+    status: Optional[str] = None
+
+
+class IntakeSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: Optional[str] = None
+    status: Optional[str] = None
+
+
+class ExhaustSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    make: Optional[str] = None
+    model: Optional[str] = None
+    config: Optional[str] = None
+    flow_class: Optional[str] = None
+
+
+class EcmSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    vendor: Optional[str] = None
+    part_number: Optional[str] = None
+    status: Optional[str] = None
+
+
+class BuildSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    displacement_ci: Optional[float] = None
+    displacement_ci_options: list[float] = Field(default_factory=list)
+    displacement_ci_status: Optional[str] = None
+    stroker_kit_pn: Optional[str] = None
+    cams: Optional[CamSpec] = None
+    cam_plate: Optional[str] = None
+    cam_bearings: Optional[str] = None
+    pistons_cylinders: Optional[str] = None
+    break_in_miles: Optional[float] = None
+    break_in_status: Optional[str] = None
+    injectors: Optional[InjectorSpec] = None
+    intake: Optional[IntakeSpec] = None
+    exhaust: Optional[ExhaustSpec] = None
+    ecm: Optional[EcmSpec] = None
+    current_calibration_source: Optional[str] = None
+    current_calibration_status: Optional[str] = None
+    afr_gauge_installed: Optional[bool] = None
+    afr_gauge_status: Optional[str] = None
+
+
+class EcmInterface(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    tool: Optional[str] = None
+    version_options: list[str] = Field(default_factory=list)
+    version_selected: Optional[str] = None
+    token_status: Optional[str] = None
+
+
+class WidebandSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    primary: Optional[str] = None
+    channels: Optional[int] = None
+    placement: list[str] = Field(default_factory=list)
+    logger: Optional[str] = None
+
+
+class DynoSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    model: Optional[str] = None
+    software: list[str] = Field(default_factory=list)
+
+
+class Hardware(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    ecm_interface: Optional[EcmInterface] = None
+    wideband: Optional[WidebandSpec] = None
+    dyno: Optional[DynoSpec] = None
+
+
+class TemplateSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: Optional[str] = None
+    dispatch_after: list[str] = Field(default_factory=list)
+    afr_strategy: Optional[str] = None
+    weighting: Optional[str] = None
+
+
+class TimingInitialDeg(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    cruise: Optional[float] = None
+    wot: Optional[float] = None
+
+
+class LambdaTargets(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    # User locked this session to 0.88 as default in plan decisions.
+    wot: float = 0.88
+    cruise_min: Optional[float] = None
+    cruise_max: Optional[float] = None
+    idle: Optional[float] = None
+
+
+class KernelSentinel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    ve_clamp_pct_per_cell: Optional[float] = None
+    timing_initial_deg: Optional[TimingInitialDeg] = None
+    knock_aware_retract: Optional[bool] = None
+    lambda_targets: Optional[LambdaTargets] = None
+    egt_redline_f: Optional[float] = None
+    egt_warn_f: Optional[float] = None
+    oil_temp_rollback_f: Optional[float] = None
+    max_consecutive_lean_cells: Optional[int] = None
+    halt_on_breach: Optional[bool] = None
+
+
+class PhaseSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: Optional[str] = None
+    method: Optional[str] = None
+    kernel: Optional[str] = None
+    pulls_budget: Optional[int] = None
+    pulls_budget_min: Optional[int] = None
+    pulls_budget_max: Optional[int] = None
+    must_complete_first: Optional[bool] = None
+    confirmation_only: Optional[bool] = None
+
+
+class AdaptiveTestPlan(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    phases: list[PhaseSpec] = Field(default_factory=list)
+    rollback_on_breach: Optional[str] = None
+
+
+class TargetRange(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    min: Optional[float] = None
+    max: Optional[float] = None
+    stretch: Optional[float] = None
+
+
+class DeltaVsCurrentState(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    hp: Optional[str] = None
+    tq_ftlb: Optional[str] = None
+
+
+class Targets(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    peak_hp: Optional[TargetRange] = None
+    peak_tq_ftlb: Optional[TargetRange] = None
+    powerband_priority_rpm: list[int] = Field(default_factory=list)
+    delta_vs_current_state: Optional[DeltaVsCurrentState] = None
+    note: Optional[str] = None
+
+
+class VerifyBlocker(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    field: str
+    blocking: bool = True
+    owner: Optional[str] = None
+    resolved: bool = False
+    resolved_at: Optional[str] = None
+    resolved_by: Optional[str] = None
+    evidence: Optional[str] = None
+
+
+class RiskFlag(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    level: str
+    id: str
+    description: str
+    trigger: Optional[str] = None
+
+
+class AgentAssignments(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    planner: Optional[str] = None
+    test_guardian: Optional[str] = None
+    kernel_sentinel: Optional[str] = None
+    integration_orchestrator: Optional[str] = None
+    documentation_scribe: Optional[str] = None
+
+
+class SessionV3(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    schema_version: str = SCHEMA_VERSION
+    session_id: str
+    created_at: Optional[str] = None
+    created_by: Optional[str] = None
+    shop: Optional[str] = None
+    proposal_ref: Optional[str] = None
+    ops_order: Optional[str] = None
+    status: Optional[str] = None
+
+    customer: Optional[Customer] = None
+    vehicle: Optional[SessionVehicle] = None
+    build_spec: Optional[BuildSpec] = None
+    verify_blockers: list[VerifyBlocker] = Field(default_factory=list)
+    hardware: Optional[Hardware] = None
+    template: Optional[TemplateSpec] = None
+    kernel_sentinel: Optional[KernelSentinel] = None
+    adaptive_test_plan: Optional[AdaptiveTestPlan] = None
+    targets: Optional[Targets] = None
+    preflight_checks: list[str] = Field(default_factory=list)
+    risk_flags: list[RiskFlag] = Field(default_factory=list)
+    session_blockers: list[str] = Field(default_factory=list)
+    agent_assignments: Optional[AgentAssignments] = None
+
+
+def validate_session_v3_payload(payload: dict[str, Any]) -> SessionV3:
+    """Validate and normalize a raw v3 payload."""
+    return SessionV3.model_validate(payload)
+
+
+def dump_session_v3_payload(payload: SessionV3) -> dict[str, Any]:
+    """Dump model to JSON-serializable dict for session.json storage."""
+    return payload.model_dump(exclude_none=True)

--- a/api/services/tuning_workspace.py
+++ b/api/services/tuning_workspace.py
@@ -92,6 +92,8 @@ class TuningSession:
     id: str
     vehicle_id: str
     base_tune_sha256: Optional[str] = None
+    schema_version: Optional[str] = None
+    v3: Optional[dict[str, Any]] = None
     status: str = "active"
     notes: str = ""
     created_at: str = field(default_factory=lambda: _utc_now())
@@ -330,6 +332,15 @@ class TuningWorkspace:
     # Sessions
     # -------------------------------------------------------------------------
 
+    @staticmethod
+    def _coerce_session_payload(payload: dict[str, Any]) -> TuningSession:
+        """Load a session JSON payload with forward-compatible field filtering."""
+        allowed = set(TuningSession.__dataclass_fields__.keys())
+        filtered = {k: v for k, v in payload.items() if k in allowed}
+        if filtered.get("v3") and not filtered.get("schema_version"):
+            filtered["schema_version"] = "dynoai.session.v3"
+        return TuningSession(**filtered)
+
     def list_sessions(self, vehicle_id: str) -> list[TuningSession]:
         sdir = self.sessions_dir(vehicle_id)
         if not sdir.exists():
@@ -338,7 +349,9 @@ class TuningWorkspace:
         for child in sorted(sdir.iterdir()):
             if child.is_dir() and (child / "session.json").exists():
                 try:
-                    sessions.append(TuningSession(**_read_json(child / "session.json")))
+                    sessions.append(
+                        self._coerce_session_payload(_read_json(child / "session.json"))
+                    )
                 except Exception:
                     continue
         return sessions
@@ -377,7 +390,7 @@ class TuningWorkspace:
         spath = self.session_json(vehicle_id, session_id)
         if not spath.exists():
             raise WorkspaceError(f"session not found: {vehicle_id}/{session_id}")
-        return TuningSession(**_read_json(spath))
+        return self._coerce_session_payload(_read_json(spath))
 
     def update_session(
         self, vehicle_id: str, session_id: str, **fields: Any
@@ -389,6 +402,75 @@ class TuningWorkspace:
                     continue
                 if hasattr(session, key):
                     setattr(session, key, val)
+            session.updated_at = _utc_now()
+            _atomic_write_json(
+                self.session_json(vehicle_id, session_id), session.to_dict()
+            )
+            return session
+
+    def get_session_v3(self, vehicle_id: str, session_id: str) -> Optional[dict[str, Any]]:
+        """Return the validated/normalized v3 payload if present."""
+        session = self.get_session(vehicle_id, session_id)
+        return session.v3
+
+    def set_session_v3(
+        self, vehicle_id: str, session_id: str, payload: dict[str, Any]
+    ) -> TuningSession:
+        """Validate and persist a `dynoai.session.v3` payload into session.json."""
+        from api.services.sessions.session_v3 import (
+            dump_session_v3_payload,
+            validate_session_v3_payload,
+        )
+
+        with self._lock:
+            session = self.get_session(vehicle_id, session_id)
+            validated = validate_session_v3_payload(payload)
+            session.v3 = dump_session_v3_payload(validated)
+            session.schema_version = validated.schema_version
+            session.updated_at = _utc_now()
+            _atomic_write_json(
+                self.session_json(vehicle_id, session_id), session.to_dict()
+            )
+            return session
+
+    def resolve_session_v3_blocker(
+        self,
+        vehicle_id: str,
+        session_id: str,
+        field_name: str,
+        resolved_by: Optional[str] = None,
+        evidence: Optional[str] = None,
+    ) -> TuningSession:
+        """
+        Mark a matching `verify_blockers[].field` entry as resolved.
+
+        Raises WorkspaceError when no v3 payload is present or blocker field is missing.
+        """
+        with self._lock:
+            session = self.get_session(vehicle_id, session_id)
+            if not session.v3:
+                raise WorkspaceError(f"session has no v3 payload: {vehicle_id}/{session_id}")
+
+            blockers = session.v3.get("verify_blockers")
+            if not isinstance(blockers, list):
+                raise WorkspaceError("session v3 verify_blockers missing or invalid")
+
+            matched = False
+            for blocker in blockers:
+                if isinstance(blocker, dict) and blocker.get("field") == field_name:
+                    blocker["resolved"] = True
+                    blocker["resolved_at"] = _utc_now()
+                    if resolved_by:
+                        blocker["resolved_by"] = resolved_by
+                    if evidence:
+                        blocker["evidence"] = evidence
+                    matched = True
+                    break
+
+            if not matched:
+                raise WorkspaceError(f"verify blocker not found: {field_name}")
+
+            session.schema_version = session.schema_version or "dynoai.session.v3"
             session.updated_at = _utc_now()
             _atomic_write_json(
                 self.session_json(vehicle_id, session_id), session.to_dict()

--- a/api/services/tuning_workspace.py
+++ b/api/services/tuning_workspace.py
@@ -408,7 +408,9 @@ class TuningWorkspace:
             )
             return session
 
-    def get_session_v3(self, vehicle_id: str, session_id: str) -> Optional[dict[str, Any]]:
+    def get_session_v3(
+        self, vehicle_id: str, session_id: str
+    ) -> Optional[dict[str, Any]]:
         """Return the validated/normalized v3 payload if present."""
         session = self.get_session(vehicle_id, session_id)
         return session.v3
@@ -449,7 +451,9 @@ class TuningWorkspace:
         with self._lock:
             session = self.get_session(vehicle_id, session_id)
             if not session.v3:
-                raise WorkspaceError(f"session has no v3 payload: {vehicle_id}/{session_id}")
+                raise WorkspaceError(
+                    f"session has no v3 payload: {vehicle_id}/{session_id}"
+                )
 
             blockers = session.v3.get("verify_blockers")
             if not isinstance(blockers, list):

--- a/docs/sessions/DAI-2026-0510-RT-FATBOY/customer_signoff.md
+++ b/docs/sessions/DAI-2026-0510-RT-FATBOY/customer_signoff.md
@@ -1,0 +1,15 @@
+# Customer Sign-Off and Safety Limits
+
+By signing below, you acknowledge and agree to the safety limits and tuning parameters established for your vehicle during this session.
+
+**Safety Limits in Effect:**
+*   **WOT Lambda Target:** `0.88` (Target Air/Fuel Ratio at Wide Open Throttle)
+*   **EGT Redline:** Enforced via `kernel_sentinel` (Engine will be halted if Exhaust Gas Temperature exceeds redline)
+*   **EGT Warning:** Enforced via `kernel_sentinel` (Operator alerted if EGT reaches warning threshold)
+*   **Oil Temperature Rollback:** Enforced via `kernel_sentinel` (Timing/fueling adjustments applied if oil temperature exceeds safe limits)
+*   **Workflow Correction Ceiling:** `±10.0%` (Maximum VE adjustment calculated per iteration, per `AutoTuneWorkflow.MAX_CORRECTION_PCT`)
+*   **Apply Correction Ceiling:** `±7.0%` (Absolute maximum VE adjustment applied to the ECU, per `DEFAULT_MAX_ADJUST_PCT`)
+
+These limits are hard-coded into our tuning engine to protect your motorcycle from thermal and mechanical stress.
+
+**Customer Signature:** ___________________________  **Date:** ____________

--- a/docs/sessions/DAI-2026-0510-RT-FATBOY/inferred_defaults.md
+++ b/docs/sessions/DAI-2026-0510-RT-FATBOY/inferred_defaults.md
@@ -1,0 +1,39 @@
+# Inferred Defaults Brief
+
+*   **Field:** `build_spec.displacement_ci`
+    *   **Value:** 103.0
+    *   **Source:** User statement ("fat boy cvo is 103 stock")
+    *   **Confidence:** High
+    *   **Kill-Switch:** Verify stock 103ci cylinders/heads are present before dispatch.
+    *   **Note:** The `.pvv` export showed `tbl_engine_displacement = 94.6 CID`. This is a Power Vision export artifact and should be ignored; the actual displacement is 103ci.
+
+*   **Field:** `vehicle.vin`
+    *   **Value:** 1HD1PNF156Y953325
+    *   **Source:** `DiagnosticsHistory.txt`
+    *   **Confidence:** High
+    *   **Kill-Switch:** Verify VIN on the frame matches before flashing.
+
+*   **Field:** `build_spec.ecm.part_number`
+    *   **Value:** 32498-05A
+    *   **Source:** `DiagnosticsHistory.txt` and `.pvv` export
+    *   **Confidence:** High
+    *   **Kill-Switch:** Verify ECM part number label matches.
+
+*   **Field:** `build_spec.ecm.current_calibration_source`
+    *   **Value:** 141NY103-001
+    *   **Source:** `DiagnosticsHistory.txt` and `.pvv` export
+    *   **Confidence:** High
+    *   **Kill-Switch:** Verify current calibration ID via Power Vision before overwriting.
+
+*   **Field:** `build_spec.injectors.flow_rate_g_s`
+    *   **Value:** 31.07 lb/hr (approx 3.91 g/s)
+    *   **Source:** `.pvv` export (`tbl_injector_size`)
+    *   **Confidence:** High
+    *   **Kill-Switch:** Verify injector part numbers match stock 31.07 lb/hr units.
+
+*   **Field:** `hardware.ecm_interface.firmware_version`
+    *   **Value:** 2.9.2-1715
+    *   **Source:** `DiagnosticsHistory.txt`
+    *   **Confidence:** High
+    *   **Kill-Switch:** Ensure Power Vision is running this firmware version.
+    *   **Note:** The Power Vision `offset_extra_seed == VIN_LOCK_EXTRA_SEED_OFFSET_v0101` assertion spam in `AssertLog.txt` is a known firmware bug on `2.9.2-1715`, NOT a security event.

--- a/docs/sessions/DAI-2026-0510-RT-FATBOY/intake_call_script.md
+++ b/docs/sessions/DAI-2026-0510-RT-FATBOY/intake_call_script.md
@@ -1,0 +1,14 @@
+# Intake Call Script
+
+1. "Can you confirm the year, make, and model of the bike?"
+2. "Are you the original owner? If not, do you know the history of any engine modifications?"
+3. "We have the displacement down as 103ci, which is stock for the CVO Fat Boy. Has the engine been bored or stroked?"
+4. "What specific exhaust system (make and model) is currently installed on the bike?"
+5. "What type of air cleaner or intake system is installed?"
+6. "Have the camshafts been changed from stock? If so, do you have the kit part number or specs?"
+7. "Are the fuel injectors original, or have they been upgraded? We see 31.07 lb/hr in the base tune."
+8. "Is there an aftermarket wideband AFR gauge installed on the bike?"
+9. "If wideband sensors are installed, where exactly are the bungs welded on the exhaust pipes?"
+10. "What fuel grade do you typically run in this bike?"
+11. "Are there any known mechanical issues, leaks, or recent repairs we should be aware of before putting it on the dyno?"
+12. "What are your primary goals for this tuning session (e.g., peak power, drivability, cooling)?"

--- a/docs/sessions/DAI-2026-0510-RT-FATBOY/risk_brief.md
+++ b/docs/sessions/DAI-2026-0510-RT-FATBOY/risk_brief.md
@@ -1,0 +1,21 @@
+# Risk Brief
+
+*   **Risk:** Injector Duty Cycle High
+    *   **Severity:** CRITICAL
+    *   **Trigger:** Injector duty cycle exceeds 85% (`INJECTOR_DUTY_HALT_PCT`).
+    *   **Mitigation:** `api/services/jetdrive/jetdrive_realtime_analysis.py` (`_detect_alerts`) emits a `CRITICAL` alert of type `INJECTOR_DUTY_HIGH`, prompting an immediate halt.
+
+*   **Risk:** Lean Condition / Implausible AFR
+    *   **Severity:** CRITICAL
+    *   **Trigger:** AFR drops below 10.0 (`AFR_MIN_PLAUSIBLE`) or exceeds 18.0 (`AFR_MAX_PLAUSIBLE`), or a lean streak exceeds the configured maximum consecutive cells.
+    *   **Mitigation:** `dynoai/core/kernel_sentinel.py` (`evaluate_lean_streak_from_grid`) and `api/services/jetdrive/jetdrive_realtime_analysis.py` (`_detect_alerts`) emit `CRITICAL` alerts, triggering `halt_on_breach`.
+
+*   **Risk:** Thermal Overload (EGT / Oil Temp)
+    *   **Severity:** CRITICAL
+    *   **Trigger:** EGT exceeds `egt_redline_f` or Oil Temp exceeds `oil_temp_rollback_f`.
+    *   **Mitigation:** `dynoai/core/kernel_sentinel.py` (`evaluate_realtime_sample`) emits a `CRITICAL` alert, triggering `halt_on_breach`.
+
+*   **Risk:** Excessive VE Correction
+    *   **Severity:** MEDIUM
+    *   **Trigger:** The calculated VE correction exceeds safe bounds.
+    *   **Mitigation:** `api/services/autotune_workflow.py` (`calculate_corrections`) clamps the calculated correction to `MAX_CORRECTION_PCT` (10.0%), and `dynoai/core/ve_operations.py` (`VEApply.apply`) enforces a hard floor of `DEFAULT_MAX_ADJUST_PCT` (7.0%). The `kernel_sentinel` can further tighten this limit.

--- a/docs/sessions/DAI-2026-0510-RT-FATBOY/runbook.md
+++ b/docs/sessions/DAI-2026-0510-RT-FATBOY/runbook.md
@@ -1,0 +1,51 @@
+# Shop Runbook: DAI-2026-0510-RT-FATBOY
+
+## 1. Preflight Checklist
+*   [ ] Verify bike condition (tires, belt/chain, no leaks).
+*   [ ] Check fluid levels (oil, primary, transmission).
+*   [ ] Confirm fuel grade matches customer intake.
+*   [ ] Warm up AFR sensors before starting the engine.
+*   [ ] **PV3 Troubleshooting Note:** The Power Vision `offset_extra_seed == VIN_LOCK_EXTRA_SEED_OFFSET_v0101` assertion spam in `AssertLog.txt` is a known firmware bug on version `2.9.2-1715`. **Ignore this spam. Do not attempt to unlock or bypass.**
+
+## 2. P0 Plausibility Run
+Before proceeding with tuning, validate the engine's baseline performance against known 103ci parameters.
+*   Perform a baseline pull to gather peak torque and BMEP/BSFC data.
+*   **Action:** POST to the plausibility endpoint:
+    ```bash
+    POST /api/workspace/vehicles/<vid>/sessions/<sid>/p0_plausibility
+    {
+        "peak_tq_ftlb": <measured_value>,
+        "peak_tq_rpm": <measured_value>,
+        "bmep_psi": <measured_value>,
+        "bsfc_lb_hp_hr": <measured_value>
+    }
+    ```
+*   Ensure the response indicates `p0_plausibility_ok: true` before advancing to P1.
+
+## 3. Phased Pulls (P0..P4)
+Execute the tuning phases sequentially. Monitor the realtime analysis engine for alerts.
+*   **P0:** Baseline validation (completed above).
+*   **P1:** VE sweep (steady-state mapping).
+*   **P2:** AFR refinement.
+*   **P3:** Timing optimization.
+*   **P4:** Final validation pull.
+*   **Stop-on-Breach:** If any `CRITICAL` alert is emitted during a pull, abort the pull immediately and return to idle.
+
+## 4. Halt + Rollback Procedure
+If the realtime engine emits a `kernel_sentinel` or `injector_duty_high` critical alert:
+1.  **Halt:** Immediately close the throttle, clutch in, and hit the kill switch if necessary.
+2.  **Assess:** Review the alert details in the UI to determine the cause (e.g., lean streak, thermal overload, injector maxed out).
+3.  **Rollback:** If the current iteration is deemed unsafe, roll back the VE corrections using the CLI tool:
+    ```bash
+    python -m dynoai.core.ve_operations rollback \
+        --current <path_to_current_ve.csv> \
+        --metadata <path_to_apply_meta.json> \
+        --output <path_to_restored_ve.csv>
+    ```
+4.  Flash the restored VE table back to the ECU before resuming.
+
+## 5. Dual-Bank Verification
+Before relying on the `use_dual_bank_weighting` feature (which applies a +15% bias to the rear cylinder):
+1.  Verify that the physical wideband sensors are correctly mapped to the data channels (e.g., Front = AFR1, Rear = AFR2).
+2.  Confirm sensor placement matches the configuration.
+3.  If sensors are swapped or single-channel, disable dual-bank weighting to prevent erroneous corrections.

--- a/dynoai/core/kernel_sentinel.py
+++ b/dynoai/core/kernel_sentinel.py
@@ -1,0 +1,228 @@
+"""
+Kernel sentinel safety checks for live capture and correction generation.
+
+The sentinel is intentionally conservative:
+- It never increases correction authority beyond existing workflow limits.
+- It can tighten correction authority per session (`ve_clamp_pct_per_cell`).
+- It can emit hard-stop breaches for thermal or lean-streak conditions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class SentinelSeverity(str, Enum):
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+@dataclass
+class SentinelBreach:
+    code: str
+    message: str
+    severity: SentinelSeverity
+    halt: bool = False
+
+
+@dataclass
+class LambdaTargets:
+    # User-approved default for this session family.
+    wot: float = 0.88
+    cruise_min: Optional[float] = None
+    cruise_max: Optional[float] = None
+    idle: Optional[float] = None
+
+
+@dataclass
+class KernelSentinelConfig:
+    ve_clamp_pct_per_cell: Optional[float] = None
+    knock_aware_retract: bool = True
+    lambda_targets: LambdaTargets = field(default_factory=LambdaTargets)
+    egt_redline_f: Optional[float] = None
+    egt_warn_f: Optional[float] = None
+    oil_temp_rollback_f: Optional[float] = None
+    max_consecutive_lean_cells: Optional[int] = None
+    halt_on_breach: bool = True
+    afr_error_tolerance: float = 0.3
+
+    @classmethod
+    def from_dict(cls, payload: dict | None) -> "KernelSentinelConfig":
+        if not payload:
+            return cls()
+
+        lambda_payload = payload.get("lambda_targets") or {}
+        lambda_targets = LambdaTargets(
+            wot=float(lambda_payload.get("wot", 0.88)),
+            cruise_min=lambda_payload.get("cruise_min"),
+            cruise_max=lambda_payload.get("cruise_max"),
+            idle=lambda_payload.get("idle"),
+        )
+
+        return cls(
+            ve_clamp_pct_per_cell=payload.get("ve_clamp_pct_per_cell"),
+            knock_aware_retract=bool(payload.get("knock_aware_retract", True)),
+            lambda_targets=lambda_targets,
+            egt_redline_f=payload.get("egt_redline_f"),
+            egt_warn_f=payload.get("egt_warn_f"),
+            oil_temp_rollback_f=payload.get("oil_temp_rollback_f"),
+            max_consecutive_lean_cells=payload.get("max_consecutive_lean_cells"),
+            halt_on_breach=bool(payload.get("halt_on_breach", True)),
+        )
+
+
+class KernelSentinel:
+    """Stateful evaluator for realtime and correction-time safety checks."""
+
+    def __init__(self, config: KernelSentinelConfig | None = None) -> None:
+        self.config = config or KernelSentinelConfig()
+        self._lean_streak = 0
+
+    def reset(self) -> None:
+        self._lean_streak = 0
+
+    def effective_max_correction_pct(self, workflow_limit_pct: float) -> float:
+        """
+        Never expand authority; only tighten it.
+        """
+        session_limit = self.config.ve_clamp_pct_per_cell
+        if session_limit is None:
+            return workflow_limit_pct
+        return min(float(workflow_limit_pct), float(session_limit))
+
+    def evaluate_realtime_sample(
+        self,
+        sample: dict,
+        *,
+        afr_error: float | None = None,
+    ) -> list[SentinelBreach]:
+        breaches: list[SentinelBreach] = []
+        cfg = self.config
+
+        egt_f = _as_float(sample.get("egt_f"))
+        if egt_f is not None:
+            if cfg.egt_redline_f is not None and egt_f >= float(cfg.egt_redline_f):
+                breaches.append(
+                    SentinelBreach(
+                        code="egt_redline",
+                        message=f"EGT {egt_f:.1f}F exceeds redline {float(cfg.egt_redline_f):.1f}F",
+                        severity=SentinelSeverity.CRITICAL,
+                        halt=cfg.halt_on_breach,
+                    )
+                )
+            elif cfg.egt_warn_f is not None and egt_f >= float(cfg.egt_warn_f):
+                breaches.append(
+                    SentinelBreach(
+                        code="egt_warn",
+                        message=f"EGT {egt_f:.1f}F exceeds warning {float(cfg.egt_warn_f):.1f}F",
+                        severity=SentinelSeverity.WARNING,
+                        halt=False,
+                    )
+                )
+
+        oil_temp_f = _as_float(sample.get("oil_temp_f"))
+        if (
+            oil_temp_f is not None
+            and cfg.oil_temp_rollback_f is not None
+            and oil_temp_f >= float(cfg.oil_temp_rollback_f)
+        ):
+            breaches.append(
+                SentinelBreach(
+                    code="oil_temp_rollback",
+                    message=(
+                        f"Oil temp {oil_temp_f:.1f}F exceeds rollback threshold "
+                        f"{float(cfg.oil_temp_rollback_f):.1f}F"
+                    ),
+                    severity=SentinelSeverity.CRITICAL,
+                    halt=cfg.halt_on_breach,
+                )
+            )
+
+        lambda_val = _as_float(sample.get("lambda"))
+        tps = _as_float(sample.get("tps")) or 0.0
+        if lambda_val is not None and tps >= 85.0 and lambda_val > cfg.lambda_targets.wot:
+            breaches.append(
+                SentinelBreach(
+                    code="lambda_wot_lean",
+                    message=(
+                        f"WOT lambda {lambda_val:.3f} is leaner than target "
+                        f"{cfg.lambda_targets.wot:.3f}"
+                    ),
+                    severity=SentinelSeverity.CRITICAL,
+                    halt=cfg.halt_on_breach,
+                )
+            )
+
+        if cfg.max_consecutive_lean_cells is not None:
+            if afr_error is not None and afr_error > cfg.afr_error_tolerance:
+                self._lean_streak += 1
+            else:
+                self._lean_streak = 0
+
+            if self._lean_streak > int(cfg.max_consecutive_lean_cells):
+                breaches.append(
+                    SentinelBreach(
+                        code="lean_streak_exceeded",
+                        message=(
+                            f"Lean streak {self._lean_streak} exceeds "
+                            f"max_consecutive_lean_cells={int(cfg.max_consecutive_lean_cells)}"
+                        ),
+                        severity=SentinelSeverity.CRITICAL,
+                        halt=cfg.halt_on_breach,
+                    )
+                )
+
+        return breaches
+
+    def evaluate_lean_streak_from_grid(
+        self,
+        ve_delta_matrix,
+        valid_mask,
+        *,
+        afr_error_tolerance: float,
+    ) -> Optional[SentinelBreach]:
+        """
+        Check for lean runs across MAP columns for any RPM row.
+
+        A lean cell is `ve_delta > afr_error_tolerance` because positive VE delta
+        means measured AFR is leaner than target and the workflow wants to add fuel.
+        """
+        limit = self.config.max_consecutive_lean_cells
+        if limit is None:
+            return None
+
+        max_run = 0
+        rows = ve_delta_matrix.shape[0]
+        cols = ve_delta_matrix.shape[1]
+
+        for i in range(rows):
+            run = 0
+            for j in range(cols):
+                if bool(valid_mask[i, j]) and float(ve_delta_matrix[i, j]) > afr_error_tolerance:
+                    run += 1
+                    max_run = max(max_run, run)
+                else:
+                    run = 0
+
+        if max_run > int(limit):
+            return SentinelBreach(
+                code="lean_streak_grid_exceeded",
+                message=(
+                    f"Lean streak across MAP cells reached {max_run}; "
+                    f"limit is {int(limit)}"
+                ),
+                severity=SentinelSeverity.CRITICAL,
+                halt=self.config.halt_on_breach,
+            )
+        return None
+
+
+def _as_float(value) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/dynoai/core/kernel_sentinel.py
+++ b/dynoai/core/kernel_sentinel.py
@@ -142,7 +142,11 @@ class KernelSentinel:
 
         lambda_val = _as_float(sample.get("lambda"))
         tps = _as_float(sample.get("tps")) or 0.0
-        if lambda_val is not None and tps >= 85.0 and lambda_val > cfg.lambda_targets.wot:
+        if (
+            lambda_val is not None
+            and tps >= 85.0
+            and lambda_val > cfg.lambda_targets.wot
+        ):
             breaches.append(
                 SentinelBreach(
                     code="lambda_wot_lean",
@@ -200,7 +204,10 @@ class KernelSentinel:
         for i in range(rows):
             run = 0
             for j in range(cols):
-                if bool(valid_mask[i, j]) and float(ve_delta_matrix[i, j]) > afr_error_tolerance:
+                if (
+                    bool(valid_mask[i, j])
+                    and float(ve_delta_matrix[i, j]) > afr_error_tolerance
+                ):
                     run += 1
                     max_run = max(max_run, run)
                 else:

--- a/dynoai/core/ve_math.py
+++ b/dynoai/core/ve_math.py
@@ -112,8 +112,10 @@ class MathConfig:
     Attributes:
         version: Math version to use (default: V2_0_0)
         max_correction_pct: Maximum correction percentage (default: 15.0 for ±15%)
-        afr_min: Minimum valid AFR value (default: 9.0)
-        afr_max: Maximum valid AFR value (default: 20.0)
+        afr_min: Minimum valid AFR value (default: AFR_MIN, currently 7.0,
+            covers the Innovate LC-1/LC-2 lower rail at 0V = 7.35 AFR).
+        afr_max: Maximum valid AFR value (default: AFR_MAX, currently 23.0,
+            covers the Innovate LC-1/LC-2 upper rail at 5V = 22.39 AFR).
         clamp_enabled: Whether to apply safety clamping (default: True)
     """
 

--- a/dynoai/core/ve_math.py
+++ b/dynoai/core/ve_math.py
@@ -38,10 +38,11 @@ References:
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Optional
 
 # Import environmental corrections
 from dynoai.core.environmental import (
+    CorrectionStandard,
     EnvironmentalConditions,
     EnvironmentalCorrectionResult,
     EnvironmentalCorrector,
@@ -242,7 +243,7 @@ def _calculate_v2_correction(afr_measured: float, afr_target: float) -> float:
 def _clamp_correction(
     correction: float,
     max_correction_pct: float,
-) -> Tuple[float, bool]:
+) -> tuple[float, bool]:
     """
     Apply safety clamping to a VE correction value.
 
@@ -381,14 +382,14 @@ def calculate_ve_correction_batch(
             f"target={len(afr_target_list)}"
         )
 
-    results = []
+    results: list[float | None] = []
     for measured, target in zip(afr_measured_list, afr_target_list):
         try:
             correction = calculate_ve_correction(
                 measured, target, version=version, config=config, clamp=clamp
             )
             results.append(correction)
-        except (AFRValidationError, VEMathError) as e:
+        except (AFRValidationError, VEMathError):
             if skip_invalid:
                 results.append(None)
             else:
@@ -516,7 +517,7 @@ def calculate_ve_correction_with_environment(
     version: Optional[MathVersion] = None,
     config: Optional[MathConfig] = None,
     clamp: bool = True,
-) -> Tuple[float, dict]:
+) -> tuple[float, dict]:
     """
     Calculate VE correction with environmental compensation.
 
@@ -585,7 +586,7 @@ def calculate_ve_correction_with_environment(
             humidity_correction=1.0,
             altitude_correction=1.0,
             ect_correction=1.0,
-            standard_used=None,
+            standard_used=CorrectionStandard.SAE_J1349,
             is_standard_day=True,
             details={},
         )

--- a/dynoai/core/ve_math.py
+++ b/dynoai/core/ve_math.py
@@ -66,9 +66,12 @@ logger = logging.getLogger(__name__)
 # Constants
 # =============================================================================
 
-# Valid AFR range for gasoline engines
-AFR_MIN: float = 9.0   # Below this = extreme rich or sensor error
-AFR_MAX: float = 20.0  # Above this = extreme lean or sensor error
+# Valid AFR range for gasoline engines.
+# Widened to [7.0, 23.0] to cover the full Innovate LC-1/LC-2 sensor rails
+# (7.35 - 22.39 AFR by default calibration). Values outside this window still
+# indicate a sensor error or a misrouted (Lambda / voltage) reading.
+AFR_MIN: float = 7.0   # Below this = extreme rich or sensor error
+AFR_MAX: float = 23.0  # Above this = extreme lean or sensor error
 
 # Stoichiometric AFR for gasoline (used for reference, not in calculation)
 STOICH_AFR_GASOLINE: float = 14.7

--- a/dynoai/core/ve_math.py
+++ b/dynoai/core/ve_math.py
@@ -20,13 +20,13 @@ AFR deviations.
 
 Usage:
     from dynoai.core.ve_math import calculate_ve_correction, MathVersion
-    
+
     # Default v2.0.0 (ratio model)
     correction = calculate_ve_correction(14.0, 13.0)
-    
+
     # Explicit version selection
     correction = calculate_ve_correction(14.0, 13.0, version=MathVersion.V2_0_0)
-    
+
     # Legacy v1.0.0 mode
     correction = calculate_ve_correction(14.0, 13.0, version=MathVersion.V1_0_0)
 
@@ -35,16 +35,16 @@ References:
     - docs/DETERMINISTIC_MATH_SPECIFICATION.md
 """
 
-from enum import Enum
-from dataclasses import dataclass
-from typing import Optional, Tuple
 import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
 
 # Import environmental corrections
 from dynoai.core.environmental import (
-    EnvironmentalCorrector,
     EnvironmentalConditions,
     EnvironmentalCorrectionResult,
+    EnvironmentalCorrector,
 )
 
 __all__ = [
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 # Widened to [7.0, 23.0] to cover the full Innovate LC-1/LC-2 sensor rails
 # (7.35 - 22.39 AFR by default calibration). Values outside this window still
 # indicate a sensor error or a misrouted (Lambda / voltage) reading.
-AFR_MIN: float = 7.0   # Below this = extreme rich or sensor error
+AFR_MIN: float = 7.0  # Below this = extreme rich or sensor error
 AFR_MAX: float = 23.0  # Above this = extreme lean or sensor error
 
 # Stoichiometric AFR for gasoline (used for reference, not in calculation)
@@ -79,26 +79,27 @@ STOICH_AFR_GASOLINE: float = 14.7
 # v1.0.0 linear model constant
 V1_VE_PER_AFR_POINT: float = 0.07  # 7% per AFR point
 
-
 # =============================================================================
 # Enums and Configuration
 # =============================================================================
 
+
 class MathVersion(Enum):
     """
     VE calculation math version selector.
-    
+
     V1_0_0: Legacy linear approximation (7% per AFR point)
         Formula: VE_correction = 1 + (AFR_error * 0.07)
         Where: AFR_error = AFR_measured - AFR_target
-        
+
     V2_0_0: Ratio model (physically accurate)
         Formula: VE_correction = AFR_measured / AFR_target
         Derived from fuel mass balance equations
     """
+
     V1_0_0 = "1.0.0"
     V2_0_0 = "2.0.0"
-    
+
     def __str__(self) -> str:
         return self.value
 
@@ -107,7 +108,7 @@ class MathVersion(Enum):
 class MathConfig:
     """
     Immutable configuration for VE math calculations.
-    
+
     Attributes:
         version: Math version to use (default: V2_0_0)
         max_correction_pct: Maximum correction percentage (default: 15.0 for ±15%)
@@ -115,12 +116,13 @@ class MathConfig:
         afr_max: Maximum valid AFR value (default: 20.0)
         clamp_enabled: Whether to apply safety clamping (default: True)
     """
+
     version: MathVersion = MathVersion.V2_0_0
     max_correction_pct: float = 15.0
     afr_min: float = AFR_MIN
     afr_max: float = AFR_MAX
     clamp_enabled: bool = True
-    
+
     def __post_init__(self) -> None:
         if self.max_correction_pct <= 0:
             raise ValueError("max_correction_pct must be positive")
@@ -149,19 +151,23 @@ def get_legacy_config() -> MathConfig:
 # Exceptions
 # =============================================================================
 
+
 class VEMathError(Exception):
     """Base exception for VE math errors."""
+
     pass
 
 
 class AFRValidationError(VEMathError):
     """Raised when AFR values are outside valid range."""
+
     pass
 
 
 # =============================================================================
 # Core Calculation Functions
 # =============================================================================
+
 
 def _validate_afr(
     afr: float,
@@ -171,13 +177,13 @@ def _validate_afr(
 ) -> None:
     """
     Validate an AFR value is within acceptable range.
-    
+
     Args:
         afr: AFR value to validate
         name: Name for error messages (e.g., "measured", "target")
         afr_min: Minimum valid AFR
         afr_max: Maximum valid AFR
-        
+
     Raises:
         AFRValidationError: If AFR is outside valid range
     """
@@ -196,16 +202,16 @@ def _validate_afr(
 def _calculate_v1_correction(afr_measured: float, afr_target: float) -> float:
     """
     Calculate VE correction using v1.0.0 linear model.
-    
+
     Formula: VE_correction = 1 + (AFR_error * 0.07)
     Where: AFR_error = AFR_measured - AFR_target
-    
+
     This is the legacy "7% per AFR point" approximation.
-    
+
     Args:
         afr_measured: Measured AFR from wideband sensor
         afr_target: Target/commanded AFR
-        
+
     Returns:
         VE correction multiplier
     """
@@ -216,15 +222,15 @@ def _calculate_v1_correction(afr_measured: float, afr_target: float) -> float:
 def _calculate_v2_correction(afr_measured: float, afr_target: float) -> float:
     """
     Calculate VE correction using v2.0.0 ratio model.
-    
+
     Formula: VE_correction = AFR_measured / AFR_target
-    
+
     This is the physically accurate model derived from fuel mass balance.
-    
+
     Args:
         afr_measured: Measured AFR from wideband sensor
         afr_target: Target/commanded AFR
-        
+
     Returns:
         VE correction multiplier
     """
@@ -237,17 +243,17 @@ def _clamp_correction(
 ) -> Tuple[float, bool]:
     """
     Apply safety clamping to a VE correction value.
-    
+
     Args:
         correction: Raw VE correction multiplier
         max_correction_pct: Maximum adjustment percentage (e.g., 15.0 for ±15%)
-        
+
     Returns:
         Tuple of (clamped_correction, was_clamped)
     """
     min_val = 1.0 - (max_correction_pct / 100.0)
     max_val = 1.0 + (max_correction_pct / 100.0)
-    
+
     if correction < min_val:
         return min_val, True
     elif correction > max_val:
@@ -265,54 +271,54 @@ def calculate_ve_correction(
 ) -> float:
     """
     Calculate VE correction factor from AFR measurements.
-    
+
     This is the primary VE calculation function for DynoAI. It supports
     multiple math versions for backwards compatibility.
-    
+
     Math Versions:
         v1.0.0: VE_correction = 1 + (AFR_error * 0.07)  [legacy]
         v2.0.0: VE_correction = AFR_measured / AFR_target  [default]
-    
+
     Interpretation:
         - correction > 1.0: Running lean, need MORE fuel (increase VE)
         - correction < 1.0: Running rich, need LESS fuel (decrease VE)
         - correction = 1.0: On target, no change needed
-    
+
     Args:
         afr_measured: Measured AFR from wideband O2 sensor
         afr_target: Target/commanded AFR from tune
         version: Math version to use (overrides config if provided)
         config: Math configuration (uses default if not provided)
         clamp: Whether to apply safety clamping (default: True)
-        
+
     Returns:
         VE correction multiplier (e.g., 1.077 means +7.7% fuel)
-        
+
     Raises:
         AFRValidationError: If AFR values are invalid
         VEMathError: If calculation fails
-        
+
     Examples:
         >>> calculate_ve_correction(14.0, 13.0)  # Lean
         1.0769230769230769
-        
+
         >>> calculate_ve_correction(12.0, 13.0)  # Rich
         0.9230769230769231
-        
+
         >>> calculate_ve_correction(13.0, 13.0)  # On target
         1.0
     """
     # Resolve configuration
     if config is None:
         config = _DEFAULT_CONFIG
-    
+
     # Version override takes precedence
     math_version = version if version is not None else config.version
-    
+
     # Validate inputs
     _validate_afr(afr_measured, "measured", config.afr_min, config.afr_max)
     _validate_afr(afr_target, "target", config.afr_min, config.afr_max)
-    
+
     # Calculate based on version
     if math_version == MathVersion.V1_0_0:
         correction = _calculate_v1_correction(afr_measured, afr_target)
@@ -320,7 +326,7 @@ def calculate_ve_correction(
         correction = _calculate_v2_correction(afr_measured, afr_target)
     else:
         raise VEMathError(f"Unknown math version: {math_version}")
-    
+
     # Apply clamping if enabled
     if clamp and config.clamp_enabled:
         correction, was_clamped = _clamp_correction(
@@ -334,7 +340,7 @@ def calculate_ve_correction(
                 correction,
                 config.max_correction_pct,
             )
-    
+
     return correction
 
 
@@ -348,10 +354,10 @@ def calculate_ve_correction_batch(
 ) -> list:
     """
     Calculate VE corrections for multiple AFR measurements.
-    
+
     Batch version of calculate_ve_correction() for efficiency when
     processing multiple data points.
-    
+
     Args:
         afr_measured_list: List of measured AFR values
         afr_target_list: List of target AFR values (same length as measured)
@@ -359,10 +365,10 @@ def calculate_ve_correction_batch(
         config: Math configuration
         clamp: Whether to apply safety clamping
         skip_invalid: If True, return None for invalid entries instead of raising
-        
+
     Returns:
         List of VE correction multipliers (or None for invalid entries if skip_invalid)
-        
+
     Raises:
         ValueError: If input lists have different lengths
         AFRValidationError: If any AFR value is invalid (unless skip_invalid=True)
@@ -372,7 +378,7 @@ def calculate_ve_correction_batch(
             f"List length mismatch: measured={len(afr_measured_list)}, "
             f"target={len(afr_target_list)}"
         )
-    
+
     results = []
     for measured, target in zip(afr_measured_list, afr_target_list):
         try:
@@ -385,7 +391,7 @@ def calculate_ve_correction_batch(
                 results.append(None)
             else:
                 raise
-    
+
     return results
 
 
@@ -393,16 +399,17 @@ def calculate_ve_correction_batch(
 # Utility Functions
 # =============================================================================
 
+
 def correction_to_percentage(correction: float) -> float:
     """
     Convert VE correction multiplier to percentage change.
-    
+
     Args:
         correction: VE correction multiplier (e.g., 1.077)
-        
+
     Returns:
         Percentage change (e.g., 7.7 for +7.7%)
-        
+
     Examples:
         >>> correction_to_percentage(1.077)
         7.7
@@ -415,13 +422,13 @@ def correction_to_percentage(correction: float) -> float:
 def percentage_to_correction(percentage: float) -> float:
     """
     Convert percentage change to VE correction multiplier.
-    
+
     Args:
         percentage: Percentage change (e.g., 7.7 for +7.7%)
-        
+
     Returns:
         VE correction multiplier (e.g., 1.077)
-        
+
     Examples:
         >>> percentage_to_correction(7.7)
         1.077
@@ -437,16 +444,16 @@ def compare_versions(
 ) -> dict:
     """
     Compare VE corrections from different math versions.
-    
+
     Useful for analysis and migration validation.
-    
+
     Args:
         afr_measured: Measured AFR
         afr_target: Target AFR
-        
+
     Returns:
         Dictionary with version comparisons
-        
+
     Examples:
         >>> compare_versions(14.0, 13.0)
         {
@@ -462,10 +469,10 @@ def compare_versions(
     v2 = calculate_ve_correction(
         afr_measured, afr_target, version=MathVersion.V2_0_0, clamp=False
     )
-    
+
     diff = abs(v2 - v1)
     diff_pct = (diff / v2) * 100.0 if v2 != 0 else 0.0
-    
+
     return {
         "afr_measured": afr_measured,
         "afr_target": afr_target,
@@ -481,7 +488,7 @@ def compare_versions(
 def get_version_info() -> dict:
     """
     Get information about the current math version configuration.
-    
+
     Returns:
         Dictionary with version information
     """
@@ -499,6 +506,7 @@ def get_version_info() -> dict:
 # Environmental Correction Integration
 # =============================================================================
 
+
 def calculate_ve_correction_with_environment(
     afr_measured: float,
     afr_target: float,
@@ -509,18 +517,18 @@ def calculate_ve_correction_with_environment(
 ) -> Tuple[float, dict]:
     """
     Calculate VE correction with environmental compensation.
-    
+
     This extends the standard VE correction to account for atmospheric
     conditions that affect air density and fuel requirements:
     - Barometric pressure / altitude
     - Ambient temperature
     - Humidity
     - Engine coolant temperature (ECT)
-    
+
     The environmental correction is applied as a multiplier to the base
     VE correction:
         final_correction = base_correction * environmental_factor
-    
+
     Args:
         afr_measured: Measured AFR from wideband O2 sensor
         afr_target: Target/commanded AFR from tune
@@ -529,18 +537,18 @@ def calculate_ve_correction_with_environment(
         version: Math version to use (overrides config if provided)
         config: Math configuration (uses default if not provided)
         clamp: Whether to apply safety clamping (default: True)
-        
+
     Returns:
         Tuple of:
         - final_correction: VE correction with environmental adjustment
         - details: Dictionary with breakdown of corrections
-        
+
     Examples:
         Standard conditions (no adjustment):
         >>> corr, details = calculate_ve_correction_with_environment(14.0, 13.0)
         >>> corr
         1.077
-        
+
         High altitude (Denver, ~5000 ft):
         >>> conditions = EnvironmentalConditions(barometric_pressure_inhg=24.89)
         >>> corr, details = calculate_ve_correction_with_environment(
@@ -548,7 +556,7 @@ def calculate_ve_correction_with_environment(
         ... )
         >>> corr
         0.896  # Less fuel needed at altitude
-        
+
     Note:
         The environmental correction affects how much fuel is ultimately
         needed, but the base VE correction is still calculated from the
@@ -564,7 +572,7 @@ def calculate_ve_correction_with_environment(
         config=config,
         clamp=False,  # We'll clamp after environmental adjustment
     )
-    
+
     # Calculate environmental correction
     if environmental_conditions is None:
         # Standard conditions = no adjustment
@@ -582,14 +590,14 @@ def calculate_ve_correction_with_environment(
     else:
         corrector = EnvironmentalCorrector()
         env_result = corrector.calculate(environmental_conditions)
-    
+
     # Combine corrections
     # The environmental factor adjusts the fuel requirement based on air density
     # For lean condition: base > 1.0 (need more fuel)
     # Environmental factor < 1.0 at altitude (less dense air needs less fuel)
     # Combined effect: the lean correction is partially offset by altitude
     final_correction = base_correction * env_result.total_correction
-    
+
     # Apply clamping if enabled
     if clamp:
         resolved_config = config if config is not None else _DEFAULT_CONFIG
@@ -597,7 +605,7 @@ def calculate_ve_correction_with_environment(
             final_correction, was_clamped = _clamp_correction(
                 final_correction, resolved_config.max_correction_pct
             )
-    
+
     # Build details dictionary
     details = {
         "base_ve_correction": base_correction,
@@ -614,7 +622,7 @@ def calculate_ve_correction_with_environment(
             "ect": env_result.ect_correction,
         },
     }
-    
+
     if environmental_conditions is not None:
         details["conditions"] = {
             "barometric_inhg": environmental_conditions.barometric_pressure_inhg,
@@ -623,7 +631,7 @@ def calculate_ve_correction_with_environment(
             "humidity_pct": environmental_conditions.humidity_percent,
             "ect_f": environmental_conditions.ect_f,
         }
-    
+
     return final_correction, details
 
 
@@ -633,17 +641,17 @@ def apply_environmental_correction(
 ) -> float:
     """
     Apply environmental correction to an existing VE correction.
-    
+
     Use this when you have already calculated a VE correction and want
     to adjust it for current environmental conditions.
-    
+
     Args:
         ve_correction: Pre-calculated VE correction multiplier
         environmental_conditions: Current atmospheric conditions
-        
+
     Returns:
         Environmentally-adjusted VE correction
-        
+
     Example:
         >>> base_corr = calculate_ve_correction(14.0, 13.0)
         >>> conditions = EnvironmentalConditions(
@@ -655,4 +663,3 @@ def apply_environmental_correction(
     corrector = EnvironmentalCorrector()
     env_result = corrector.calculate(environmental_conditions)
     return ve_correction * env_result.total_correction
-

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -187,6 +187,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -548,6 +549,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -596,6 +598,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -4015,8 +4018,7 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -4163,6 +4165,7 @@
             "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -4173,6 +4176,7 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -4252,6 +4256,7 @@
             "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.0",
                 "@typescript-eslint/types": "8.56.0",
@@ -4650,6 +4655,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4690,7 +4696,6 @@
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4825,6 +4830,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5381,6 +5387,7 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -5580,8 +5587,7 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/dom-helpers": {
             "version": "5.2.1",
@@ -5618,7 +5624,8 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/embla-carousel-react": {
             "version": "8.6.0",
@@ -5812,6 +5819,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -6942,7 +6950,6 @@
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -7232,6 +7239,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -7283,7 +7291,6 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -7299,7 +7306,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -7312,8 +7318,7 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -7356,6 +7361,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
             "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7396,6 +7402,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
             "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -7417,6 +7424,7 @@
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
             "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -7927,7 +7935,8 @@
             "version": "4.1.18",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
             "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tapable": {
             "version": "2.3.0",
@@ -8116,6 +8125,7 @@
             "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8304,6 +8314,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
             "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",

--- a/tests/api/test_dispatch_readiness_fatboy.py
+++ b/tests/api/test_dispatch_readiness_fatboy.py
@@ -1,0 +1,165 @@
+"""End-to-end dispatch readiness flow for FATBOY v3 sessions."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from werkzeug.datastructures import MultiDict
+
+
+@pytest.fixture(autouse=True)
+def _isolated_workspace(tmp_path, monkeypatch):
+    """Point workspace singleton at an isolated tmp directory per test."""
+    from api.services import tuning_workspace as ws_mod
+
+    monkeypatch.setenv("DYNOAI_WORKSPACE_ROOT", str(tmp_path / "vehicles"))
+    ws_mod.reset_workspace()
+    yield
+    ws_mod.reset_workspace()
+
+
+def test_dispatch_readiness_fatboy_transitions_to_ready(client):
+    vid = "fatboy_cvo"
+    create_vehicle = client.post(
+        "/api/workspace/vehicles",
+        json={
+            "id": vid,
+            "name": "2006 CVO Fat Boy",
+            "year": 2006,
+            "make": "harley",
+            "model": "flstfse2",
+            "displacement_ci": 103.0,
+        },
+    )
+    assert create_vehicle.status_code == 201
+
+    create_session = client.post(f"/api/workspace/vehicles/{vid}/sessions", json={})
+    assert create_session.status_code == 201
+    sid = create_session.get_json()["id"]
+
+    v3_payload = {
+        "schema_version": "dynoai.session.v3",
+        "session_id": sid,
+        "status": "blocked_pending_verify",
+        "vehicle": {
+            "year": 2006,
+            "make": "harley",
+            "model": "flstfse2 cvo fatboy",
+            "vin": "1HD1PNF156Y953325",
+        },
+        "build_spec": {
+            "displacement_ci": 103.0,
+            "injectors": {"flow_rate_g_s": 3.91, "status": "verify_pending"},
+        },
+        "verify_blockers": [
+            {
+                "field": "build_spec.displacement_ci",
+                "blocking": True,
+                "resolved": False,
+                "owner": "planner",
+            },
+            {
+                "field": "build_spec.injectors.flow_rate_g_s",
+                "blocking": True,
+                "resolved": False,
+                "owner": "planner",
+            },
+            {
+                "field": "vehicle.vin",
+                "blocking": True,
+                "resolved": False,
+                "owner": "planner",
+            },
+        ],
+        "session_blockers": [],
+        "template": {"dispatch_after": ["dispatch_ready"]},
+        "kernel_sentinel": {"halt_on_breach": True, "lambda_targets": {"wot": 0.88}},
+    }
+    upsert_v3 = client.post(
+        f"/api/workspace/vehicles/{vid}/sessions/{sid}/v3",
+        json=v3_payload,
+    )
+    assert upsert_v3.status_code == 200
+
+    readiness_before = client.get(
+        f"/api/workspace/vehicles/{vid}/sessions/{sid}/dispatch_readiness"
+    )
+    assert readiness_before.status_code == 200
+    readiness_before_body = readiness_before.get_json()
+    assert readiness_before_body["ready"] is False
+    assert readiness_before_body["gates"]["workspace_ready"] is False
+    assert readiness_before_body["gates"]["verify_blockers_resolved"] is False
+    assert readiness_before_body["gates"]["p0_plausibility_ok"] is False
+
+    # Meet workspace-ready gate: one base tune and one AFR pull.
+    pvv_bytes = (
+        b'<?xml version="1.0"?><PVV>'
+        b'<Item name="tbl_ve_tps_based_front_cyl"><Cell value="1.0"/></Item></PVV>'
+    )
+    dyno_txt = (
+        b"Time\tmph\tft-lbs\thp\tLC1 Volts Petrol AFR\tLC2 Volts Petrol AFR2\n"
+        b"0.5\t30.0\t12.0\t10.0\t13.5\t13.4\n"
+        b"1.0\t40.0\t18.0\t22.0\t13.2\t13.1\n"
+        b"1.5\t55.0\t30.0\t35.0\t12.9\t12.8\n"
+        b"2.0\t70.0\t42.0\t48.0\t12.7\t12.6\n"
+    )
+    upload = client.post(
+        f"/api/workspace/vehicles/{vid}/sessions/{sid}/upload",
+        data=MultiDict(
+            [
+                ("files", (io.BytesIO(pvv_bytes), "stock.pvv")),
+                ("files", (io.BytesIO(dyno_txt), "pull.txt")),
+            ]
+        ),
+        content_type="multipart/form-data",
+    )
+    assert upload.status_code == 200
+
+    # Resolve all verify blockers.
+    for field_name in [
+        "build_spec.displacement_ci",
+        "build_spec.injectors.flow_rate_g_s",
+        "vehicle.vin",
+    ]:
+        resolve = client.post(
+            f"/api/workspace/vehicles/{vid}/sessions/{sid}/v3/resolve_blocker",
+            json={
+                "field": field_name,
+                "resolved_by": "test",
+                "evidence": "fixture-confirmed",
+            },
+        )
+        assert resolve.status_code == 200
+
+    # Run P0 plausibility.
+    p0 = client.post(
+        f"/api/workspace/vehicles/{vid}/sessions/{sid}/p0_plausibility",
+        json={
+            "known_displacement_ci": 103.0,
+            "peak_tq_ftlb": 105.0,
+            "peak_tq_rpm": 3200.0,
+        },
+    )
+    assert p0.status_code == 200
+    assert p0.get_json()["p0_plausibility"]["status"] == "pass"
+
+    # Meet status gate (dispatch_after includes dispatch_ready).
+    patch = client.patch(
+        f"/api/workspace/vehicles/{vid}/sessions/{sid}",
+        json={"status": "dispatch_ready"},
+    )
+    assert patch.status_code == 200
+
+    readiness_after = client.get(
+        f"/api/workspace/vehicles/{vid}/sessions/{sid}/dispatch_readiness"
+    )
+    assert readiness_after.status_code == 200
+    readiness_after_body = readiness_after.get_json()
+    assert readiness_after_body["ready"] is True
+    assert readiness_after_body["gates"]["workspace_ready"] is True
+    assert readiness_after_body["gates"]["verify_blockers_resolved"] is True
+    assert readiness_after_body["gates"]["session_blockers_clear"] is True
+    assert readiness_after_body["gates"]["status_gate_ok"] is True
+    assert readiness_after_body["gates"]["kernel_halt_on_breach"] is True
+    assert readiness_after_body["gates"]["p0_plausibility_ok"] is True

--- a/tests/api/test_jetdrive_realtime_analysis.py
+++ b/tests/api/test_jetdrive_realtime_analysis.py
@@ -10,28 +10,16 @@ Tests:
 """
 
 import time
-from unittest.mock import MagicMock
 
 import pytest
 
 from api.services.jetdrive.jetdrive_realtime_analysis import (
-    AFR_MAX_PLAUSIBLE,
-    AFR_MIN_PLAUSIBLE,
     FROZEN_RPM_THRESHOLD_SEC,
-    MAP_BIN_SIZE,
-    MAP_MAX,
-    MAP_MIN,
-    RPM_BIN_SIZE,
-    RPM_MAX,
-    RPM_MIN,
+    INJECTOR_DUTY_HALT_PCT,
     TOTAL_CELLS,
-    Alert,
     AlertSeverity,
     AlertType,
-    CoverageCell,
-    QualityMetrics,
     RealtimeAnalysisEngine,
-    VEDeltaCell,
     get_realtime_engine,
     reset_realtime_engine,
 )
@@ -370,7 +358,7 @@ class TestAlertDetection:
         # Wait for stale threshold (use shorter for test)
         # Note: In production this is 5 seconds, but we can check the logic
         # by manually checking freshness
-        state = engine.get_state()
+        engine.get_state()
 
         # Initially no stale alerts (just sent data)
         stale_alerts = [a for a in engine.alerts if a.type == AlertType.STALE_CHANNEL]
@@ -399,6 +387,37 @@ class TestAlertDetection:
         # Should only have one alert (duplicate suppressed)
         afr_alerts = [a for a in engine.alerts if a.type == AlertType.IMPLAUSIBLE_AFR]
         assert len(afr_alerts) == 1
+
+    @staticmethod
+    def test_injector_duty_high_alert(engine):
+        """Injector duty >85% should raise critical alert."""
+        # duty_pct = pw_ms * rpm / 1200 => 90% requires 21.6ms at 5000 rpm
+        sample = make_sample(rpm=5000.0, tps=90.0)
+        sample["injector_pulsewidth_ms"] = 22.0
+        engine.on_aggregated_sample(sample)
+
+        duty_alerts = [a for a in engine.alerts if a.type == AlertType.INJECTOR_DUTY_HIGH]
+        assert duty_alerts, "Expected injector duty alert"
+        assert duty_alerts[0].severity == AlertSeverity.CRITICAL
+        assert duty_alerts[0].value is not None
+        assert duty_alerts[0].value > INJECTOR_DUTY_HALT_PCT
+
+    @staticmethod
+    def test_kernel_sentinel_alert_from_egt(engine):
+        """Sentinel breach should be surfaced as a kernel_sentinel alert."""
+        engine.set_kernel_sentinel_config(
+            {
+                "egt_redline_f": 1450.0,
+                "halt_on_breach": True,
+            }
+        )
+        sample = make_sample(rpm=4000.0, tps=95.0, afr=13.2)
+        sample["egt_f"] = 1500.0
+        engine.on_aggregated_sample(sample)
+
+        sentinel_alerts = [a for a in engine.alerts if a.type == AlertType.KERNEL_SENTINEL]
+        assert sentinel_alerts, "Expected kernel sentinel alert"
+        assert sentinel_alerts[0].severity == AlertSeverity.CRITICAL
 
 
 # =============================================================================

--- a/tests/api/test_jetdrive_realtime_analysis.py
+++ b/tests/api/test_jetdrive_realtime_analysis.py
@@ -396,7 +396,9 @@ class TestAlertDetection:
         sample["injector_pulsewidth_ms"] = 22.0
         engine.on_aggregated_sample(sample)
 
-        duty_alerts = [a for a in engine.alerts if a.type == AlertType.INJECTOR_DUTY_HIGH]
+        duty_alerts = [
+            a for a in engine.alerts if a.type == AlertType.INJECTOR_DUTY_HIGH
+        ]
         assert duty_alerts, "Expected injector duty alert"
         assert duty_alerts[0].severity == AlertSeverity.CRITICAL
         assert duty_alerts[0].value is not None
@@ -415,7 +417,9 @@ class TestAlertDetection:
         sample["egt_f"] = 1500.0
         engine.on_aggregated_sample(sample)
 
-        sentinel_alerts = [a for a in engine.alerts if a.type == AlertType.KERNEL_SENTINEL]
+        sentinel_alerts = [
+            a for a in engine.alerts if a.type == AlertType.KERNEL_SENTINEL
+        ]
         assert sentinel_alerts, "Expected kernel sentinel alert"
         assert sentinel_alerts[0].severity == AlertSeverity.CRITICAL
 

--- a/tests/api/test_workspace_endpoint.py
+++ b/tests/api/test_workspace_endpoint.py
@@ -260,3 +260,115 @@ class TestPeakHpUnitsAreNotConflated:
         # column so it must stay None rather than be impersonated by mph.
         assert body["peak_hp_rpm"] is None or (body["peak_hp_rpm"]
                                                != body["peak_hp_mph"])
+
+
+class TestSessionV3Routes:
+
+    @staticmethod
+    def _bootstrap(client):
+        client.post("/api/workspace/vehicles", json={"name": "CVO Fat Boy", "year": 2006})
+        resp = client.post("/api/workspace/vehicles/cvo_fat_boy/sessions", json={})
+        return resp.get_json()["id"]
+
+    @staticmethod
+    def test_v3_upsert_get_and_blocker_resolution(client):
+        sid = TestSessionV3Routes._bootstrap(client)
+        v3_payload = {
+            "schema_version": "dynoai.session.v3",
+            "session_id": sid,
+            "status": "blocked_pending_verify",
+            "verify_blockers": [
+                {
+                    "field": "build_spec.displacement_ci",
+                    "blocking": True,
+                    "resolved": False,
+                    "owner": "planner",
+                }
+            ],
+            "template": {"dispatch_after": ["dispatch_ready"]},
+            "kernel_sentinel": {"halt_on_breach": True, "lambda_targets": {"wot": 0.88}},
+            "build_spec": {"displacement_ci": 103.0},
+        }
+
+        upsert = client.post(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3",
+            json=v3_payload,
+        )
+        assert upsert.status_code == 200
+        upsert_body = upsert.get_json()
+        assert upsert_body["schema_version"] == "dynoai.session.v3"
+        assert "v3" in upsert_body
+
+        fetch = client.get(f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3")
+        assert fetch.status_code == 200
+        fetch_body = fetch.get_json()
+        assert fetch_body["session_id"] == sid
+
+        resolve = client.post(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3/resolve_blocker",
+            json={"field": "build_spec.displacement_ci", "resolved_by": "qa"},
+        )
+        assert resolve.status_code == 200
+        resolve_body = resolve.get_json()
+        assert resolve_body["v3"]["verify_blockers"][0]["resolved"] is True
+
+    @staticmethod
+    def test_dispatch_readiness_requires_p0(client):
+        sid = TestSessionV3Routes._bootstrap(client)
+        v3_payload = {
+            "schema_version": "dynoai.session.v3",
+            "session_id": sid,
+            "status": "dispatch_ready",
+            "verify_blockers": [],
+            "session_blockers": [],
+            "template": {"dispatch_after": ["dispatch_ready"]},
+            "kernel_sentinel": {"halt_on_breach": True, "lambda_targets": {"wot": 0.88}},
+            "build_spec": {"displacement_ci": 103.0},
+        }
+        client.post(f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3", json=v3_payload)
+
+        readiness_before = client.get(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/dispatch_readiness"
+        )
+        assert readiness_before.status_code == 200
+        assert readiness_before.get_json()["gates"]["p0_plausibility_ok"] is False
+
+        p0_resp = client.post(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/p0_plausibility",
+            json={"peak_tq_ftlb": 105.0, "peak_tq_rpm": 3200.0},
+        )
+        assert p0_resp.status_code == 200
+
+        readiness_after = client.get(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/dispatch_readiness"
+        )
+        assert readiness_after.status_code == 200
+        after_body = readiness_after.get_json()
+        assert after_body["gates"]["p0_plausibility_ok"] is True
+
+    @staticmethod
+    def test_phase_progression_routes(client):
+        sid = TestSessionV3Routes._bootstrap(client)
+        v3_payload = {
+            "schema_version": "dynoai.session.v3",
+            "session_id": sid,
+            "status": "active",
+            "adaptive_test_plan": {
+                "phases": [{"id": "P0"}, {"id": "P1"}, {"id": "P2"}]
+            },
+            "execution": {"active_phase": "P0", "completed_phases": []},
+        }
+        client.post(f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3", json=v3_payload)
+
+        phase_get = client.get(f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/phases")
+        assert phase_get.status_code == 200
+        assert phase_get.get_json()["active_phase"] == "P0"
+
+        phase_complete = client.post(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/phases/complete",
+            json={"phase_id": "P0"},
+        )
+        assert phase_complete.status_code == 200
+        complete_body = phase_complete.get_json()
+        assert "P0" in complete_body["completed_phases"]
+        assert complete_body["active_phase"] == "P1"

--- a/tests/api/test_workspace_endpoint.py
+++ b/tests/api/test_workspace_endpoint.py
@@ -20,7 +20,6 @@ def _isolated_workspace(tmp_path, monkeypatch):
 
 
 class TestVehicleLifecycle:
-
     @staticmethod
     def test_list_vehicles_empty(client):
         resp = client.get("/api/workspace/vehicles")
@@ -31,10 +30,7 @@ class TestVehicleLifecycle:
     def test_create_vehicle(client):
         resp = client.post(
             "/api/workspace/vehicles",
-            json={
-                "name": "Racile 2006 Dyna 88ci",
-                "year": 2006
-            },
+            json={"name": "Racile 2006 Dyna 88ci", "year": 2006},
         )
         assert resp.status_code == 201
         body = resp.get_json()
@@ -54,7 +50,6 @@ class TestVehicleLifecycle:
 
 
 class TestSessionLifecycle:
-
     @staticmethod
     def _make_vehicle(client):
         client.post("/api/workspace/vehicles", json={"name": "Dyna"})
@@ -62,15 +57,15 @@ class TestSessionLifecycle:
     @staticmethod
     def test_create_session_and_status(client):
         TestSessionLifecycle._make_vehicle(client)
-        resp = client.post("/api/workspace/vehicles/dyna/sessions",
-                           json={"notes": "baseline"})
+        resp = client.post(
+            "/api/workspace/vehicles/dyna/sessions", json={"notes": "baseline"}
+        )
         assert resp.status_code == 201
         session = resp.get_json()
         assert session["active_iteration_id"] == "iter_0"
 
         sid = session["id"]
-        status_resp = client.get(
-            f"/api/workspace/vehicles/dyna/sessions/{sid}/status")
+        status_resp = client.get(f"/api/workspace/vehicles/dyna/sessions/{sid}/status")
         assert status_resp.status_code == 200
         status = status_resp.get_json()
         assert status["ready_to_analyze"] is False
@@ -78,15 +73,11 @@ class TestSessionLifecycle:
 
 
 class TestUploadRouting:
-
     @staticmethod
     def _bootstrap(client):
         client.post(
             "/api/workspace/vehicles",
-            json={
-                "name": "Dyna",
-                "year": 2006
-            },
+            json={"name": "Dyna", "year": 2006},
         )
         resp = client.post("/api/workspace/vehicles/dyna/sessions", json={})
         return resp.get_json()["id"]
@@ -95,9 +86,11 @@ class TestUploadRouting:
     def test_upload_routes_pvv_to_base_tune(client):
         sid = TestUploadRouting._bootstrap(client)
 
-        pvv_bytes = (b'<?xml version="1.0"?><PVV>'
-                     b'<Item name="tbl_ve_tps_based_front_cyl">'
-                     b'<Cell value="1.0"/></Item></PVV>')
+        pvv_bytes = (
+            b'<?xml version="1.0"?><PVV>'
+            b'<Item name="tbl_ve_tps_based_front_cyl">'
+            b'<Cell value="1.0"/></Item></PVV>'
+        )
         data = {
             "files": (io.BytesIO(pvv_bytes), "tune.pvv"),
         }
@@ -135,20 +128,26 @@ class TestUploadRouting:
     @staticmethod
     def test_upload_multiple_files_mixed(client):
         sid = TestUploadRouting._bootstrap(client)
-        pvv_bytes = (b'<?xml version="1.0"?><PVV>'
-                     b'<Item name="tbl_ve_tps_based_front_cyl">'
-                     b'<Cell value="1.0"/></Item></PVV>')
+        pvv_bytes = (
+            b'<?xml version="1.0"?><PVV>'
+            b'<Item name="tbl_ve_tps_based_front_cyl">'
+            b'<Cell value="1.0"/></Item></PVV>'
+        )
         wp8_bytes = b"\xfe\xce\xfa\xce" + b"\x00" * 32
-        dyno_txt = (b"Time\tSpeed (mph)\tPower (hp)\tLC1 AFR\tLC2 AFR\n"
-                    b"0.5\t30\t10\t13.5\t13.4\n"
-                    b"1.0\t40\t22\t13.2\t13.1\n"
-                    b"1.5\t55\t35\t12.9\t12.8\n")
+        dyno_txt = (
+            b"Time\tSpeed (mph)\tPower (hp)\tLC1 AFR\tLC2 AFR\n"
+            b"0.5\t30\t10\t13.5\t13.4\n"
+            b"1.0\t40\t22\t13.2\t13.1\n"
+            b"1.5\t55\t35\t12.9\t12.8\n"
+        )
 
-        data = MultiDict([
-            ("files", (io.BytesIO(pvv_bytes), "tune.pvv")),
-            ("files", (io.BytesIO(wp8_bytes), "run.wp8")),
-            ("files", (io.BytesIO(dyno_txt), "pull.txt")),
-        ])
+        data = MultiDict(
+            [
+                ("files", (io.BytesIO(pvv_bytes), "tune.pvv")),
+                ("files", (io.BytesIO(wp8_bytes), "run.wp8")),
+                ("files", (io.BytesIO(dyno_txt), "pull.txt")),
+            ]
+        )
         resp = client.post(
             f"/api/workspace/vehicles/dyna/sessions/{sid}/upload",
             data=data,
@@ -182,16 +181,17 @@ class TestUploadRouting:
 
 
 class TestAnalyzeResultPersistenceConsistency:
-
     @staticmethod
     def _bootstrap_with_pulls(client):
         client.post("/api/workspace/vehicles", json={"name": "Dyna"})
         resp = client.post("/api/workspace/vehicles/dyna/sessions", json={})
         sid = resp.get_json()["id"]
 
-        pvv = (b'<?xml version="1.0"?><PVV>'
-               b'<Item name="tbl_ve_tps_based_front_cyl">'
-               b'<Cell value="1.0"/></Item></PVV>')
+        pvv = (
+            b'<?xml version="1.0"?><PVV>'
+            b'<Item name="tbl_ve_tps_based_front_cyl">'
+            b'<Cell value="1.0"/></Item></PVV>'
+        )
         # Real Dynojet TXT shape with all six columns: time, mph, ft-lbs, hp,
         # LC1 Volts Petrol AFR, LC2 Volts Petrol AFR2 (volts here are decoy
         # column names; the values in this fixture are already AFR-range).
@@ -201,11 +201,14 @@ class TestAnalyzeResultPersistenceConsistency:
             b"1.0\t40.0\t18.0\t22.0\t13.2\t13.1\n"
             b"1.5\t55.0\t30.0\t35.0\t12.9\t12.8\n"
             b"2.0\t70.0\t42.0\t48.0\t12.7\t12.6\n"
-            b"2.5\t85.0\t52.0\t55.0\t12.6\t12.5\n")
-        data = MultiDict([
-            ("files", (io.BytesIO(pvv), "tune.pvv")),
-            ("files", (io.BytesIO(dyno_txt), "pull.txt")),
-        ])
+            b"2.5\t85.0\t52.0\t55.0\t12.6\t12.5\n"
+        )
+        data = MultiDict(
+            [
+                ("files", (io.BytesIO(pvv), "tune.pvv")),
+                ("files", (io.BytesIO(dyno_txt), "pull.txt")),
+            ]
+        )
         client.post(
             f"/api/workspace/vehicles/dyna/sessions/{sid}/upload",
             data=data,
@@ -218,24 +221,25 @@ class TestAnalyzeResultPersistenceConsistency:
         import json
         from pathlib import Path
 
-        sid = TestAnalyzeResultPersistenceConsistency._bootstrap_with_pulls(
-            client)
+        sid = TestAnalyzeResultPersistenceConsistency._bootstrap_with_pulls(client)
 
         resp = client.post(
-            f"/api/workspace/vehicles/dyna/sessions/{sid}/analyze", json={})
+            f"/api/workspace/vehicles/dyna/sessions/{sid}/analyze", json={}
+        )
         body = resp.get_json()
         assert body["analysis_json_path"], "API must surface the analysis path"
         assert "success" in body
 
         on_disk = Path(body["analysis_json_path"])
-        assert on_disk.exists(
-        ), "analysis JSON must be on disk at the reported path"
+        assert on_disk.exists(), "analysis JSON must be on disk at the reported path"
 
         persisted = json.loads(on_disk.read_text(encoding="utf-8"))
         assert persisted["success"] == body["success"], (
-            "persisted success must match API response")
+            "persisted success must match API response"
+        )
         assert persisted["analysis_json_path"] == body["analysis_json_path"], (
-            "persisted analysis_json_path must self-reference its own file")
+            "persisted analysis_json_path must self-reference its own file"
+        )
         assert persisted["correction_pvv_path"] == body["correction_pvv_path"]
 
 
@@ -248,25 +252,27 @@ class TestPeakHpUnitsAreNotConflated:
 
     @staticmethod
     def test_peak_hp_mph_kept_separate_from_peak_hp_rpm(client):
-        sid = TestAnalyzeResultPersistenceConsistency._bootstrap_with_pulls(
-            client)
+        sid = TestAnalyzeResultPersistenceConsistency._bootstrap_with_pulls(client)
         resp = client.post(
-            f"/api/workspace/vehicles/dyna/sessions/{sid}/analyze", json={})
+            f"/api/workspace/vehicles/dyna/sessions/{sid}/analyze", json={}
+        )
         body = resp.get_json()
         assert "peak_hp_mph" in body, "peak_hp_mph field must exist on result"
         # The Dynojet TXT path populates peak_hp_mph.
         assert body["peak_hp_mph"] is not None
         # peak_hp_rpm comes only from real RPM data; this fixture has no RPM
         # column so it must stay None rather than be impersonated by mph.
-        assert body["peak_hp_rpm"] is None or (body["peak_hp_rpm"]
-                                               != body["peak_hp_mph"])
+        assert body["peak_hp_rpm"] is None or (
+            body["peak_hp_rpm"] != body["peak_hp_mph"]
+        )
 
 
 class TestSessionV3Routes:
-
     @staticmethod
     def _bootstrap(client):
-        client.post("/api/workspace/vehicles", json={"name": "CVO Fat Boy", "year": 2006})
+        client.post(
+            "/api/workspace/vehicles", json={"name": "CVO Fat Boy", "year": 2006}
+        )
         resp = client.post("/api/workspace/vehicles/cvo_fat_boy/sessions", json={})
         return resp.get_json()["id"]
 
@@ -286,7 +292,10 @@ class TestSessionV3Routes:
                 }
             ],
             "template": {"dispatch_after": ["dispatch_ready"]},
-            "kernel_sentinel": {"halt_on_breach": True, "lambda_targets": {"wot": 0.88}},
+            "kernel_sentinel": {
+                "halt_on_breach": True,
+                "lambda_targets": {"wot": 0.88},
+            },
             "build_spec": {"displacement_ci": 103.0},
         }
 
@@ -322,10 +331,15 @@ class TestSessionV3Routes:
             "verify_blockers": [],
             "session_blockers": [],
             "template": {"dispatch_after": ["dispatch_ready"]},
-            "kernel_sentinel": {"halt_on_breach": True, "lambda_targets": {"wot": 0.88}},
+            "kernel_sentinel": {
+                "halt_on_breach": True,
+                "lambda_targets": {"wot": 0.88},
+            },
             "build_spec": {"displacement_ci": 103.0},
         }
-        client.post(f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3", json=v3_payload)
+        client.post(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3", json=v3_payload
+        )
 
         readiness_before = client.get(
             f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/dispatch_readiness"
@@ -358,9 +372,13 @@ class TestSessionV3Routes:
             },
             "execution": {"active_phase": "P0", "completed_phases": []},
         }
-        client.post(f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3", json=v3_payload)
+        client.post(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/v3", json=v3_payload
+        )
 
-        phase_get = client.get(f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/phases")
+        phase_get = client.get(
+            f"/api/workspace/vehicles/cvo_fat_boy/sessions/{sid}/phases"
+        )
         assert phase_get.status_code == 200
         assert phase_get.get_json()["active_phase"] == "P0"
 

--- a/tests/unit/test_autotune_safety_clamp.py
+++ b/tests/unit/test_autotune_safety_clamp.py
@@ -1,0 +1,98 @@
+"""Safety clamp and sentinel guard tests for AutoTuneWorkflow."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from api.services.autotune_workflow import AFRAnalysisResult, AutoTuneWorkflow
+from dynoai.core.ve_operations import DEFAULT_MAX_ADJUST_PCT
+
+
+def _build_session_with_single_cell(
+    workflow: AutoTuneWorkflow, ve_delta_pct: float, *, hits: int = 10
+):
+    session = workflow.create_session(run_id="safety_clamp_test")
+    error_df = pd.DataFrame([[ve_delta_pct]], index=[2000], columns=[50])
+    ve_delta_df = pd.DataFrame([[ve_delta_pct]], index=[2000], columns=[50])
+    hit_df = pd.DataFrame([[hits]], index=[2000], columns=[50])
+    session.afr_analysis = AFRAnalysisResult(
+        mean_error_pct=float(ve_delta_pct),
+        mean_afr_error=1.0,
+        zones_rich=0,
+        zones_lean=1,
+        zones_ok=0,
+        zones_no_data=0,
+        max_lean_pct=float(max(0.0, ve_delta_pct)),
+        max_rich_pct=float(min(0.0, ve_delta_pct)),
+        error_by_zone=error_df,
+        ve_delta_by_zone=ve_delta_df,
+        hit_count_by_zone=hit_df,
+    )
+    return session
+
+
+def test_clamp_floors_are_locked():
+    """
+    Regression guard:
+    - AutoTune workflow correction ceiling remains ±10%
+    - VE apply/rollback ceiling remains ±7%
+    """
+    assert AutoTuneWorkflow.MAX_CORRECTION_PCT == 10.0
+    assert DEFAULT_MAX_ADJUST_PCT == 7.0
+
+
+def test_sentinel_cannot_expand_correction_authority():
+    """
+    Session sentinel may tighten clamp authority but must never widen it.
+    """
+    workflow = AutoTuneWorkflow(
+        max_correction_pct=10.0,
+        kernel_sentinel_config={"ve_clamp_pct_per_cell": 25.0},
+    )
+    session = _build_session_with_single_cell(workflow, ve_delta_pct=30.0)
+    result = workflow.calculate_corrections(session)
+    assert result is not None
+    assert np.isclose(result.correction_table[0, 0], 1.10, atol=1e-6)
+    assert result.max_correction_pct <= 10.0001
+
+
+def test_sentinel_can_tighten_correction_authority():
+    workflow = AutoTuneWorkflow(
+        max_correction_pct=10.0,
+        kernel_sentinel_config={"ve_clamp_pct_per_cell": 5.0},
+    )
+    session = _build_session_with_single_cell(workflow, ve_delta_pct=30.0)
+    result = workflow.calculate_corrections(session)
+    assert result is not None
+    assert np.isclose(result.correction_table[0, 0], 1.05, atol=1e-6)
+    assert result.max_correction_pct <= 5.0001
+
+
+def test_sentinel_halts_on_lean_streak_grid():
+    workflow = AutoTuneWorkflow(
+        kernel_sentinel_config={
+            "max_consecutive_lean_cells": 1,
+            "halt_on_breach": True,
+        }
+    )
+    session = workflow.create_session(run_id="lean_streak_test")
+    ve_delta_df = pd.DataFrame([[0.5, 0.6, 0.7]], index=[2500], columns=[50, 60, 70])
+    hit_df = pd.DataFrame([[10, 10, 10]], index=[2500], columns=[50, 60, 70])
+    session.afr_analysis = AFRAnalysisResult(
+        mean_error_pct=0.6,
+        mean_afr_error=0.6,
+        zones_rich=0,
+        zones_lean=3,
+        zones_ok=0,
+        zones_no_data=0,
+        max_lean_pct=0.7,
+        max_rich_pct=0.0,
+        error_by_zone=ve_delta_df.copy(),
+        ve_delta_by_zone=ve_delta_df,
+        hit_count_by_zone=hit_df,
+    )
+    result = workflow.calculate_corrections(session)
+    assert result is None
+    assert session.status == "halted_on_sentinel"
+    assert any("Lean streak" in e for e in session.errors)

--- a/tests/unit/test_dual_bank_weighting.py
+++ b/tests/unit/test_dual_bank_weighting.py
@@ -1,0 +1,40 @@
+"""Dual-bank AFR weighting tests for AutoTuneWorkflow."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from api.services.autotune_workflow import AutoTuneWorkflow
+
+
+def _sample_dual_bank_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Engine RPM": [3000.0, 3000.0, 3000.0],
+            "MAP kPa": [60.0, 60.0, 60.0],
+            "AFR Front": [12.0, 12.0, 12.0],
+            "AFR Rear": [14.0, 14.0, 14.0],
+            "Time_ms": [0, 10, 20],
+        }
+    )
+
+
+def test_dual_bank_weighting_biases_toward_rear_bank():
+    df = _sample_dual_bank_df()
+
+    # Baseline path: picks one AFR column (front-biased in this fixture).
+    single = AutoTuneWorkflow(use_dual_bank_weighting=False)
+    single_session = single.create_session(run_id="single")
+    assert single.import_dataframe(single_session, df)
+    single_result = single.analyze_afr(single_session)
+    assert single_result is not None
+
+    # Dual-bank path blends front + rear with rear weighted +15%.
+    dual = AutoTuneWorkflow(use_dual_bank_weighting=True, rear_bank_weight=1.15)
+    dual_session = dual.create_session(run_id="dual")
+    assert dual.import_dataframe(dual_session, df)
+    dual_result = dual.analyze_afr(dual_session)
+    assert dual_result is not None
+
+    # At MAP 60 target is 13.5. Front-only (12.0) is richer than weighted blend (~13.07).
+    assert dual_result.mean_afr_error > single_result.mean_afr_error

--- a/tests/unit/test_session_backcompat_roundtrip.py
+++ b/tests/unit/test_session_backcompat_roundtrip.py
@@ -10,13 +10,8 @@ import pytest
 
 from api.services.tuning_workspace import TuningWorkspace
 
-
 LEGACY_SESSION_PATH = (
-    Path("vehicles")
-    / "doodledyna"
-    / "sessions"
-    / "20260421_233219"
-    / "session.json"
+    Path("vehicles") / "doodledyna" / "sessions" / "20260421_233219" / "session.json"
 )
 
 

--- a/tests/unit/test_session_backcompat_roundtrip.py
+++ b/tests/unit/test_session_backcompat_roundtrip.py
@@ -1,0 +1,38 @@
+"""Backward-compatibility roundtrip for legacy session.json payloads."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from api.services.tuning_workspace import TuningWorkspace
+
+
+LEGACY_SESSION_PATH = (
+    Path("vehicles")
+    / "doodledyna"
+    / "sessions"
+    / "20260421_233219"
+    / "session.json"
+)
+
+
+def test_doodledyna_legacy_session_roundtrip():
+    if not LEGACY_SESSION_PATH.exists():
+        pytest.skip(f"legacy fixture missing: {LEGACY_SESSION_PATH}")
+
+    payload = json.loads(LEGACY_SESSION_PATH.read_text(encoding="utf-8"))
+    with tempfile.TemporaryDirectory(prefix="ws_backcompat_") as tmp:
+        ws = TuningWorkspace(root=tmp)
+        session = ws._coerce_session_payload(payload)  # compatibility loader coverage
+
+    dumped = session.to_dict()
+    assert dumped["id"] == payload["id"]
+    assert dumped["vehicle_id"] == payload["vehicle_id"]
+    assert dumped["status"] == payload["status"]
+    assert dumped["active_iteration_id"] == payload["active_iteration_id"]
+    assert dumped["schema_version"] is None
+    assert dumped["v3"] is None

--- a/tests/unit/test_tunelab_autotune_cli.py
+++ b/tests/unit/test_tunelab_autotune_cli.py
@@ -1,0 +1,613 @@
+"""Tests for the TuneLab autotune preview CLI entrypoint."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pandas as pd  # type: ignore[import-untyped]
+
+ROOT = Path(__file__).resolve().parents[2]
+CLI_MODULE = "tools.autotune.tunelab_entrypoint"
+
+
+def _run_cli(
+    *,
+    log_csv: Path,
+    output_dir: Path,
+    extra_args: list[str] | None = None,
+    run_id: str = "tests/f1_cli",
+):
+    cmd = [
+        sys.executable,
+        "-m",
+        CLI_MODULE,
+        "--log-csv",
+        str(log_csv),
+        "--output-dir",
+        str(output_dir),
+        "--run-id",
+        run_id,
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    return subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, check=False)
+
+
+def _run_apply_cli(
+    *,
+    run_id: str,
+    output_dir: Path,
+    base_front: Path,
+    base_rear: Path,
+    extra_args: list[str] | None = None,
+):
+    cmd = [
+        sys.executable,
+        "-m",
+        CLI_MODULE,
+        "apply",
+        "--run-id",
+        run_id,
+        "--output-dir",
+        str(output_dir),
+        "--base-front",
+        str(base_front),
+        "--base-rear",
+        str(base_rear),
+        "--mode",
+        "dual_cylinder",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    return subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, check=False)
+
+
+def _build_dual_afr_frame(*, front_afr: float, rear_afr: float) -> pd.DataFrame:
+    rows: list[dict[str, float]] = []
+    # Provide enough hits per cell for workflow MIN_HITS_PER_ZONE=3.
+    base_cells = [(2000, 40), (3000, 60), (4000, 80)]
+    timestamp = 0
+    for rpm, map_kpa in base_cells:
+        for _ in range(6):
+            rows.append(
+                {
+                    "timestamp_ms": timestamp,
+                    "Engine RPM": float(rpm),
+                    "MAP kPa": float(map_kpa),
+                    "AFR Meas F": float(front_afr),
+                    "AFR Meas R": float(rear_afr),
+                    "TPS": 25.0,
+                }
+            )
+            timestamp += 10
+    return pd.DataFrame(rows)
+
+
+def _load_summary(summary_path: Path) -> dict:
+    return json.loads(summary_path.read_text(encoding="utf-8"))
+
+
+def _load_grid(csv_path: Path) -> pd.DataFrame:
+    df = pd.read_csv(csv_path, index_col=0)
+    df.index = df.index.astype(int)
+    df.columns = df.columns.astype(int)
+    return df
+
+
+def _write_base_ve_csv(path: Path, rpm_axis: list[float], map_axis: list[float], value: float) -> None:
+    def _fmt(axis_value: float) -> str:
+        as_float = float(axis_value)
+        if as_float.is_integer():
+            return str(int(as_float))
+        return f"{as_float:.3f}".rstrip("0").rstrip(".")
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write("RPM," + ",".join(_fmt(v) for v in map_axis) + "\n")
+        for rpm in rpm_axis:
+            row = [f"{float(value):.4f}" for _ in map_axis]
+            handle.write(_fmt(rpm) + "," + ",".join(row) + "\n")
+
+
+def test_cli_missing_afr_column_returns_nonzero(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.5).drop(columns=["AFR Meas R"])
+    log_csv = tmp_path / "missing_rear.csv"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=tmp_path / "out")
+
+    assert result.returncode != 0
+    assert "[F1][ERR] missing_column: AFR Meas R" in result.stderr
+
+
+def test_cli_happy_path_emits_both_csvs_and_summary(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.2, rear_afr=13.1)
+    log_csv = tmp_path / "input.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    front_csv = out_dir / "VE_Front_Correction_2D.csv"
+    rear_csv = out_dir / "VE_Rear_Correction_2D.csv"
+    summary_json = out_dir / "correction_summary.json"
+    assert front_csv.exists()
+    assert rear_csv.exists()
+    assert summary_json.exists()
+
+    front_grid = _load_grid(front_csv)
+    rear_grid = _load_grid(rear_csv)
+    assert front_grid.shape == (11, 9)
+    assert rear_grid.shape == (11, 9)
+    assert front_grid.apply(pd.to_numeric, errors="coerce").notna().all().all()
+    assert rear_grid.apply(pd.to_numeric, errors="coerce").notna().all().all()
+
+
+def test_cli_summary_schema_v1_fields_present(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2)
+    log_csv = tmp_path / "schema.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    expected_top_level = {
+        "schema_version",
+        "log_csv",
+        "run_id",
+        "mode",
+        "afr_target_source",
+        "grid",
+        "front",
+        "rear",
+        "overall_max_pct",
+        "warn_threshold_pct",
+        "over_warn_threshold",
+        "safety",
+    }
+    assert expected_top_level.issubset(summary.keys())
+    assert summary["mode"] == "dual_cylinder"
+
+
+def test_preview_summary_includes_safety_block(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2)
+    log_csv = tmp_path / "safety_block.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    safety = summary.get("safety")
+    assert isinstance(safety, dict)
+    assert float(safety["block_threshold_pct"]) == 25.0
+    assert float(safety["warn_threshold_pct"]) == 10.0
+    assert safety["apply_blocked"] is False
+    assert safety["apply_blocked_reasons"] == []
+
+
+def test_preview_blocks_on_extreme_correction(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=20.5, rear_afr=20.1)
+    log_csv = tmp_path / "extreme.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    safety = summary["safety"]
+    assert safety["apply_blocked"] is True
+    assert any(reason["type"] == "extreme_correction" for reason in safety["apply_blocked_reasons"])
+
+
+def test_preview_blocks_in_single_cylinder_mode(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.1, rear_afr=13.1).drop(columns=["AFR Meas F"])
+    log_csv = tmp_path / "single_mode.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(
+        log_csv=log_csv,
+        output_dir=out_dir,
+        extra_args=["--single-cylinder", "rear"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    safety = summary["safety"]
+    assert safety["apply_blocked"] is True
+    assert any(reason["type"] == "partial_cylinder" for reason in safety["apply_blocked_reasons"])
+
+
+def test_preview_emit_pvv_patch_writes_pvv(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.3)
+    log_csv = tmp_path / "emit_pvv.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(
+        log_csv=log_csv,
+        output_dir=out_dir,
+        extra_args=["--emit-pvv-patch"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    pvv_name = summary.get("pvv_patch")
+    assert isinstance(pvv_name, str) and pvv_name.endswith(".pvv")
+    pvv_path = out_dir / pvv_name
+    assert pvv_path.exists()
+    root = ET.parse(pvv_path).getroot()
+    item_names = {item.attrib.get("name", "") for item in root.findall("Item")}
+    assert any(name.startswith("VE Correction") for name in item_names)
+
+
+def test_preview_pvv_patch_default_off(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.3)
+    log_csv = tmp_path / "pvv_default_off.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    assert "pvv_patch" not in summary
+    assert list(out_dir.glob("*.pvv")) == []
+
+
+def test_apply_subcommand_writes_ve_applied_and_session_log(tmp_path: Path) -> None:
+    run_id = f"tests_apply_{tmp_path.name}"
+    run_dir = ROOT / "runs" / run_id
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    try:
+        frame = _build_dual_afr_frame(front_afr=14.2, rear_afr=13.1)
+        log_csv = tmp_path / "apply_input.csv"
+        out_dir = tmp_path / "out"
+        frame.to_csv(log_csv, index=False)
+
+        preview_result = _run_cli(log_csv=log_csv, output_dir=out_dir, run_id=run_id)
+        assert preview_result.returncode == 0, preview_result.stderr
+
+        summary = _load_summary(out_dir / "correction_summary.json")
+        rpm_axis = summary["grid"]["rpm_axis"]
+        map_axis = summary["grid"]["map_axis"]
+        base_front = tmp_path / "base_front.csv"
+        base_rear = tmp_path / "base_rear.csv"
+        _write_base_ve_csv(base_front, rpm_axis, map_axis, 100.0)
+        _write_base_ve_csv(base_rear, rpm_axis, map_axis, 102.0)
+
+        apply_result = _run_apply_cli(
+            run_id=run_id,
+            output_dir=out_dir,
+            base_front=base_front,
+            base_rear=base_rear,
+        )
+        assert apply_result.returncode == 0, apply_result.stderr
+        assert "apply_front=" in apply_result.stdout
+        assert "apply_rear=" in apply_result.stdout
+        assert "session_log=" in apply_result.stdout
+
+        line = next(
+            line for line in apply_result.stdout.splitlines() if line.startswith("[F1][OK]")
+        )
+        match = re.search(
+            r"apply_front=(\S+)\s+apply_rear=(\S+)\s+session_log=(\S+)",
+            line,
+        )
+        assert match is not None
+        apply_front_path = Path(match.group(1))
+        apply_rear_path = Path(match.group(2))
+        session_log_path = Path(match.group(3))
+        assert apply_front_path.exists()
+        assert apply_rear_path.exists()
+        assert session_log_path.exists()
+
+        applied_front_grid = _load_grid(apply_front_path)
+        applied_rear_grid = _load_grid(apply_rear_path)
+        assert applied_front_grid.shape == (11, 9)
+        assert applied_rear_grid.shape == (11, 9)
+
+        session_log = json.loads(session_log_path.read_text(encoding="utf-8"))
+        apply_events = [
+            event for event in session_log.get("events", []) if event.get("type") == "apply"
+        ]
+        assert len(apply_events) >= 2
+    finally:
+        if run_dir.exists():
+            shutil.rmtree(run_dir)
+
+
+def test_preview_schema_v1_adds_safety_field(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2)
+    log_csv = tmp_path / "schema_safety.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    assert "safety" in summary
+
+
+def test_cli_afr_target_source_defaults_to_static_map_curve_v1(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.3)
+    log_csv = tmp_path / "target_source.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    assert summary["afr_target_source"] == "static_map_curve_v1"
+
+
+def test_cli_summary_flags_over_threshold(tmp_path: Path) -> None:
+    # Very lean front/rear AFR values should trigger warn threshold gating.
+    frame = _build_dual_afr_frame(front_afr=20.0, rear_afr=19.8)
+    log_csv = tmp_path / "lean.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    summary = _load_summary(out_dir / "correction_summary.json")
+    assert float(summary["warn_threshold_pct"]) == 10.0
+    assert summary["over_warn_threshold"] is True
+    assert float(summary["overall_max_pct"]) > 10.0
+
+
+def test_cli_front_and_rear_correction_differ(tmp_path: Path) -> None:
+    rows: list[dict[str, float]] = []
+    timestamp = 0
+    # Target at MAP=60 is 13.5. Make front lean and rear rich in the same cell.
+    for _ in range(10):
+        rows.append(
+            {
+                "timestamp_ms": timestamp,
+                "Engine RPM": 3000.0,
+                "MAP kPa": 60.0,
+                "AFR Meas F": 15.2,
+                "AFR Meas R": 12.6,
+            }
+        )
+        timestamp += 10
+    # Add another populated cell so both runs have multiple valid bins.
+    for _ in range(10):
+        rows.append(
+            {
+                "timestamp_ms": timestamp,
+                "Engine RPM": 4000.0,
+                "MAP kPa": 80.0,
+                "AFR Meas F": 12.9,
+                "AFR Meas R": 12.9,
+            }
+        )
+        timestamp += 10
+
+    frame = pd.DataFrame(rows)
+    log_csv = tmp_path / "diff.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    front_grid = _load_grid(out_dir / "VE_Front_Correction_2D.csv")
+    rear_grid = _load_grid(out_dir / "VE_Rear_Correction_2D.csv")
+
+    front_cell = float(front_grid.loc[3000, 60])
+    rear_cell = float(rear_grid.loc[3000, 60])
+    assert front_cell > 1.0
+    assert rear_cell < 1.0
+    assert abs(front_cell - rear_cell) > 0.001
+
+
+def test_cli_accepts_lc2_voltage_columns(tmp_path: Path) -> None:
+    """Voltage-labeled LC-2 columns should be converted server-side via wideband_rescale."""
+    # LC-2 default: 0V->7.35 AFR, 5V->22.39 AFR (slope 3.008, intercept 7.35).
+    # Voltages chosen to stay inside AutoTuneWorkflow's valid AFR range [9, 20].
+    #   v=3.5V -> ~17.88 AFR (lean vs target ~13.5 @ MAP 60)
+    #   v=2.0V -> ~13.37 AFR (near target)
+    rows: list[dict[str, float]] = []
+    timestamp = 0
+    for rpm, map_kpa, v_front, v_rear in [
+        (3000, 60, 3.5, 2.0),
+        (4000, 80, 3.4, 2.05),
+    ]:
+        for _ in range(8):
+            rows.append(
+                {
+                    "timestamp_ms": timestamp,
+                    "Engine RPM": float(rpm),
+                    "MAP kPa": float(map_kpa),
+                    "LC2 Volts Petrol AFR1": float(v_front),
+                    "LC2 Volts Petrol AFR2": float(v_rear),
+                }
+            )
+            timestamp += 10
+    frame = pd.DataFrame(rows)
+    log_csv = tmp_path / "voltage.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    front_grid = _load_grid(out_dir / "VE_Front_Correction_2D.csv")
+    rear_grid = _load_grid(out_dir / "VE_Rear_Correction_2D.csv")
+    # 4.5 V -> ~20.9 AFR (lean) -> request more fuel -> front correction > 1 somewhere.
+    # 2.0 V -> ~13.4 AFR (near target at MAP=60 -> 13.5), so rear should hover near 1.
+    assert front_grid.values.max() > 1.0
+    assert abs(front_grid.loc[3000, 60] - rear_grid.loc[3000, 60]) > 0.01
+
+
+def test_cli_single_cylinder_rear_only_emits_rear_outputs(tmp_path: Path) -> None:
+    """--single-cylinder rear with only rear AFR present must succeed and write only rear CSV."""
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2).drop(columns=["AFR Meas F"])
+    log_csv = tmp_path / "rear_only.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(
+        log_csv=log_csv,
+        output_dir=out_dir,
+        extra_args=["--single-cylinder", "rear"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out_dir / "VE_Rear_Correction_2D.csv").exists()
+    assert not (out_dir / "VE_Front_Correction_2D.csv").exists()
+
+    summary = _load_summary(out_dir / "correction_summary.json")
+    assert summary["mode"] == "single_cylinder_rear"
+    assert summary["front"] is None
+    assert isinstance(summary["rear"], dict)
+
+
+def test_cli_single_cylinder_front_only_emits_front_outputs(tmp_path: Path) -> None:
+    """--single-cylinder front with only front AFR present must succeed and write only front CSV."""
+    frame = _build_dual_afr_frame(front_afr=14.5, rear_afr=13.2).drop(columns=["AFR Meas R"])
+    log_csv = tmp_path / "front_only.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(
+        log_csv=log_csv,
+        output_dir=out_dir,
+        extra_args=["--single-cylinder", "front"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out_dir / "VE_Front_Correction_2D.csv").exists()
+    assert not (out_dir / "VE_Rear_Correction_2D.csv").exists()
+
+    summary = _load_summary(out_dir / "correction_summary.json")
+    assert summary["mode"] == "single_cylinder_front"
+    assert summary["rear"] is None
+    assert isinstance(summary["front"], dict)
+
+
+def test_cli_single_cylinder_flag_overrides_missing_column_error(tmp_path: Path) -> None:
+    """Without the flag, missing AFR Meas F errors. With --single-cylinder rear, CLI succeeds."""
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2).drop(columns=["AFR Meas F"])
+    log_csv = tmp_path / "needs_override.csv"
+    frame.to_csv(log_csv, index=False)
+
+    # Baseline: no flag -> error.
+    strict_result = _run_cli(log_csv=log_csv, output_dir=tmp_path / "strict")
+    assert strict_result.returncode != 0
+    assert "missing_column: AFR Meas F" in strict_result.stderr
+
+    # With flag -> success.
+    override_result = _run_cli(
+        log_csv=log_csv,
+        output_dir=tmp_path / "single",
+        extra_args=["--single-cylinder", "rear"],
+    )
+    assert override_result.returncode == 0, override_result.stderr
+
+
+def test_cli_accepts_lambda_columns(tmp_path: Path) -> None:
+    """Lambda-labeled columns should be converted to AFR via the canonical helper.
+
+    Math check at MAP=60 kPa (target AFR = 13.5):
+      lambda 0.95 -> 13.965 AFR (slightly lean) -> correction > 1.0
+      lambda 0.88 -> 12.936 AFR (slightly rich) -> correction < 1.0
+    """
+    rows: list[dict[str, float]] = []
+    timestamp = 0
+    for rpm, map_kpa, lam_front, lam_rear in [
+        (3000, 60, 0.95, 0.88),
+        (4000, 80, 0.93, 0.90),
+    ]:
+        for _ in range(8):
+            rows.append(
+                {
+                    "timestamp_ms": timestamp,
+                    "Engine RPM": float(rpm),
+                    "MAP kPa": float(map_kpa),
+                    "WBO2 LAMBDA Front": float(lam_front),
+                    "WBO2 LAMBDA Rear": float(lam_rear),
+                }
+            )
+            timestamp += 10
+    frame = pd.DataFrame(rows)
+    log_csv = tmp_path / "lambda.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    front_grid = _load_grid(out_dir / "VE_Front_Correction_2D.csv")
+    rear_grid = _load_grid(out_dir / "VE_Rear_Correction_2D.csv")
+    # Front (0.95 lambda) -> lean -> correction > 1.0 at (3000, 60).
+    # Rear  (0.88 lambda) -> rich -> correction < 1.0 at (3000, 60).
+    assert front_grid.loc[3000, 60] > 1.0
+    assert rear_grid.loc[3000, 60] < 1.0
+
+
+def test_cli_rescales_lambda_values_in_afr_columns(tmp_path: Path) -> None:
+    """Rescue path: an 'AFR Meas' column whose values are in Lambda range
+    (0.5-1.5) should be auto-rescaled to AFR via lambda_to_afr, so the
+    workflow doesn't reject 0.90 with the old 'outside valid range' error.
+    """
+    rows: list[dict[str, float]] = []
+    timestamp = 0
+    for rpm, map_kpa, afr_front_lambda, afr_rear_lambda in [
+        (3000, 60, 0.95, 0.88),
+        (4000, 80, 0.93, 0.90),
+    ]:
+        for _ in range(8):
+            rows.append(
+                {
+                    "timestamp_ms": timestamp,
+                    "Engine RPM": float(rpm),
+                    "MAP kPa": float(map_kpa),
+                    # AFR-named columns but values are Lambda-range.
+                    "AFR Meas F": float(afr_front_lambda),
+                    "AFR Meas R": float(afr_rear_lambda),
+                }
+            )
+            timestamp += 10
+    frame = pd.DataFrame(rows)
+    log_csv = tmp_path / "afr_but_lambda.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    front_grid = _load_grid(out_dir / "VE_Front_Correction_2D.csv")
+    rear_grid = _load_grid(out_dir / "VE_Rear_Correction_2D.csv")
+    assert front_grid.shape == (11, 9)
+    assert rear_grid.shape == (11, 9)
+
+
+def test_cli_stdout_summary_line_format(tmp_path: Path) -> None:
+    frame = _build_dual_afr_frame(front_afr=14.2, rear_afr=13.0)
+    log_csv = tmp_path / "stdout.csv"
+    out_dir = tmp_path / "out"
+    frame.to_csv(log_csv, index=False)
+
+    result = _run_cli(log_csv=log_csv, output_dir=out_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert re.search(
+        r"^\[F1\]\[OK\] summary=.+correction_summary\.json$",
+        result.stdout.strip(),
+        flags=re.MULTILINE,
+    )

--- a/tests/unit/test_tunelab_autotune_cli.py
+++ b/tests/unit/test_tunelab_autotune_cli.py
@@ -100,7 +100,9 @@ def _load_grid(csv_path: Path) -> pd.DataFrame:
     return df
 
 
-def _write_base_ve_csv(path: Path, rpm_axis: list[float], map_axis: list[float], value: float) -> None:
+def _write_base_ve_csv(
+    path: Path, rpm_axis: list[float], map_axis: list[float], value: float
+) -> None:
     def _fmt(axis_value: float) -> str:
         as_float = float(axis_value)
         if as_float.is_integer():
@@ -115,7 +117,9 @@ def _write_base_ve_csv(path: Path, rpm_axis: list[float], map_axis: list[float],
 
 
 def test_cli_missing_afr_column_returns_nonzero(tmp_path: Path) -> None:
-    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.5).drop(columns=["AFR Meas R"])
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.5).drop(
+        columns=["AFR Meas R"]
+    )
     log_csv = tmp_path / "missing_rear.csv"
     frame.to_csv(log_csv, index=False)
 
@@ -207,11 +211,16 @@ def test_preview_blocks_on_extreme_correction(tmp_path: Path) -> None:
     summary = _load_summary(out_dir / "correction_summary.json")
     safety = summary["safety"]
     assert safety["apply_blocked"] is True
-    assert any(reason["type"] == "extreme_correction" for reason in safety["apply_blocked_reasons"])
+    assert any(
+        reason["type"] == "extreme_correction"
+        for reason in safety["apply_blocked_reasons"]
+    )
 
 
 def test_preview_blocks_in_single_cylinder_mode(tmp_path: Path) -> None:
-    frame = _build_dual_afr_frame(front_afr=14.1, rear_afr=13.1).drop(columns=["AFR Meas F"])
+    frame = _build_dual_afr_frame(front_afr=14.1, rear_afr=13.1).drop(
+        columns=["AFR Meas F"]
+    )
     log_csv = tmp_path / "single_mode.csv"
     out_dir = tmp_path / "out"
     frame.to_csv(log_csv, index=False)
@@ -226,7 +235,10 @@ def test_preview_blocks_in_single_cylinder_mode(tmp_path: Path) -> None:
     summary = _load_summary(out_dir / "correction_summary.json")
     safety = summary["safety"]
     assert safety["apply_blocked"] is True
-    assert any(reason["type"] == "partial_cylinder" for reason in safety["apply_blocked_reasons"])
+    assert any(
+        reason["type"] == "partial_cylinder"
+        for reason in safety["apply_blocked_reasons"]
+    )
 
 
 def test_preview_emit_pvv_patch_writes_pvv(tmp_path: Path) -> None:
@@ -299,7 +311,9 @@ def test_apply_subcommand_writes_ve_applied_and_session_log(tmp_path: Path) -> N
         assert "session_log=" in apply_result.stdout
 
         line = next(
-            line for line in apply_result.stdout.splitlines() if line.startswith("[F1][OK]")
+            line
+            for line in apply_result.stdout.splitlines()
+            if line.startswith("[F1][OK]")
         )
         match = re.search(
             r"apply_front=(\S+)\s+apply_rear=(\S+)\s+session_log=(\S+)",
@@ -320,7 +334,9 @@ def test_apply_subcommand_writes_ve_applied_and_session_log(tmp_path: Path) -> N
 
         session_log = json.loads(session_log_path.read_text(encoding="utf-8"))
         apply_events = [
-            event for event in session_log.get("events", []) if event.get("type") == "apply"
+            event
+            for event in session_log.get("events", [])
+            if event.get("type") == "apply"
         ]
         assert len(apply_events) >= 2
     finally:
@@ -456,7 +472,9 @@ def test_cli_accepts_lc2_voltage_columns(tmp_path: Path) -> None:
 
 def test_cli_single_cylinder_rear_only_emits_rear_outputs(tmp_path: Path) -> None:
     """--single-cylinder rear with only rear AFR present must succeed and write only rear CSV."""
-    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2).drop(columns=["AFR Meas F"])
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2).drop(
+        columns=["AFR Meas F"]
+    )
     log_csv = tmp_path / "rear_only.csv"
     out_dir = tmp_path / "out"
     frame.to_csv(log_csv, index=False)
@@ -479,7 +497,9 @@ def test_cli_single_cylinder_rear_only_emits_rear_outputs(tmp_path: Path) -> Non
 
 def test_cli_single_cylinder_front_only_emits_front_outputs(tmp_path: Path) -> None:
     """--single-cylinder front with only front AFR present must succeed and write only front CSV."""
-    frame = _build_dual_afr_frame(front_afr=14.5, rear_afr=13.2).drop(columns=["AFR Meas R"])
+    frame = _build_dual_afr_frame(front_afr=14.5, rear_afr=13.2).drop(
+        columns=["AFR Meas R"]
+    )
     log_csv = tmp_path / "front_only.csv"
     out_dir = tmp_path / "out"
     frame.to_csv(log_csv, index=False)
@@ -500,9 +520,13 @@ def test_cli_single_cylinder_front_only_emits_front_outputs(tmp_path: Path) -> N
     assert isinstance(summary["front"], dict)
 
 
-def test_cli_single_cylinder_flag_overrides_missing_column_error(tmp_path: Path) -> None:
+def test_cli_single_cylinder_flag_overrides_missing_column_error(
+    tmp_path: Path,
+) -> None:
     """Without the flag, missing AFR Meas F errors. With --single-cylinder rear, CLI succeeds."""
-    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2).drop(columns=["AFR Meas F"])
+    frame = _build_dual_afr_frame(front_afr=14.0, rear_afr=13.2).drop(
+        columns=["AFR Meas F"]
+    )
     log_csv = tmp_path / "needs_override.csv"
     frame.to_csv(log_csv, index=False)
 

--- a/tests/unit/test_tunelab_autotune_cli.py
+++ b/tests/unit/test_tunelab_autotune_cli.py
@@ -588,7 +588,7 @@ def test_cli_accepts_lambda_columns(tmp_path: Path) -> None:
 def test_cli_rescales_lambda_values_in_afr_columns(tmp_path: Path) -> None:
     """Rescue path: an 'AFR Meas' column whose values are in Lambda range
     (0.5-1.5) should be auto-rescaled to AFR via lambda_to_afr, so the
-    workflow doesn't reject 0.90 with the old 'outside valid range' error.
+    workflow doesn't reject 0.90 against the widened [7.0, 23.0] AFR bounds.
     """
     rows: list[dict[str, float]] = []
     timestamp = 0

--- a/tests/unit/test_tunelab_autotune_cli.py
+++ b/tests/unit/test_tunelab_autotune_cli.py
@@ -434,7 +434,8 @@ def test_cli_front_and_rear_correction_differ(tmp_path: Path) -> None:
 def test_cli_accepts_lc2_voltage_columns(tmp_path: Path) -> None:
     """Voltage-labeled LC-2 columns should be converted server-side via wideband_rescale."""
     # LC-2 default: 0V->7.35 AFR, 5V->22.39 AFR (slope 3.008, intercept 7.35).
-    # Voltages chosen to stay inside AutoTuneWorkflow's valid AFR range [9, 20].
+    # Voltages chosen to stay inside MathConfig's AFR_MIN/AFR_MAX bounds
+    # (currently 7.0/23.0, widened to cover LC-1/LC-2 sensor rails).
     #   v=3.5V -> ~17.88 AFR (lean vs target ~13.5 @ MAP 60)
     #   v=2.0V -> ~13.37 AFR (near target)
     rows: list[dict[str, float]] = []

--- a/tests/unit/test_tuning_workspace.py
+++ b/tests/unit/test_tuning_workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import tempfile
 from pathlib import Path
@@ -127,3 +128,64 @@ def test_find_vehicle_by_ecu_signature(ws: TuningWorkspace):
     ws.update_vehicle(vehicle.id, ecu_signature="deadbeef")
     assert ws.find_vehicle_by_ecu_signature("deadbeef").id == vehicle.id
     assert ws.find_vehicle_by_ecu_signature("nope") is None
+
+
+def test_legacy_session_payload_still_loads(ws: TuningWorkspace):
+    vehicle = ws.create_vehicle(name="Legacy Bike")
+    sid = "legacy_20260510"
+    sdir = ws.session_dir(vehicle.id, sid)
+    sdir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": sid,
+        "vehicle_id": vehicle.id,
+        "base_tune_sha256": None,
+        "status": "active",
+        "notes": "",
+        "created_at": "2026-04-21T23:32:19.429Z",
+        "updated_at": "2026-04-21T23:32:19.433Z",
+        "active_iteration_id": "iter_0",
+    }
+    ws.session_json(vehicle.id, sid).write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = ws.get_session(vehicle.id, sid)
+    assert loaded.id == sid
+    assert loaded.schema_version is None
+    assert loaded.v3 is None
+
+
+def test_set_v3_and_resolve_blocker(ws: TuningWorkspace):
+    vehicle = ws.create_vehicle(name="V3 Bike")
+    session = ws.create_session(vehicle.id)
+
+    payload = {
+        "schema_version": "dynoai.session.v3",
+        "session_id": session.id,
+        "status": "blocked_pending_verify",
+        "verify_blockers": [
+            {
+                "field": "build_spec.displacement_ci",
+                "blocking": True,
+                "resolved": False,
+                "owner": "planner",
+            }
+        ],
+        "template": {"dispatch_after": ["dispatch_ready"]},
+        "kernel_sentinel": {"halt_on_breach": True, "lambda_targets": {"wot": 0.88}},
+    }
+
+    updated = ws.set_session_v3(vehicle.id, session.id, payload)
+    assert updated.schema_version == "dynoai.session.v3"
+    assert updated.v3 is not None
+    assert updated.v3["session_id"] == session.id
+
+    resolved = ws.resolve_session_v3_blocker(
+        vehicle.id,
+        session.id,
+        "build_spec.displacement_ci",
+        resolved_by="test",
+        evidence="customer confirmed",
+    )
+    assert resolved.v3 is not None
+    blocker = resolved.v3["verify_blockers"][0]
+    assert blocker["resolved"] is True
+    assert blocker["resolved_by"] == "test"

--- a/tests/unit/test_ve_math.py
+++ b/tests/unit/test_ve_math.py
@@ -353,7 +353,7 @@ class TestInputValidation:
 
     @staticmethod
     def test_afr_too_low_raises():
-        """AFR below minimum should raise AFRValidationError."""
+        """AFR below AFR_MIN should raise AFRValidationError."""
         with pytest.raises(AFRValidationError):
             calculate_ve_correction(5.0, 13.0)  # measured too low
 
@@ -361,19 +361,19 @@ class TestInputValidation:
             calculate_ve_correction(13.0, 5.0)  # target too low
 
         with pytest.raises(AFRValidationError):
-            calculate_ve_correction(8.9, 13.0)  # just below minimum
+            calculate_ve_correction(AFR_MIN - 0.1, 13.0)  # just below minimum
 
     @staticmethod
     def test_afr_too_high_raises():
-        """AFR above maximum should raise AFRValidationError."""
+        """AFR above AFR_MAX should raise AFRValidationError."""
         with pytest.raises(AFRValidationError):
-            calculate_ve_correction(25.0, 13.0)  # measured too high
+            calculate_ve_correction(AFR_MAX + 10.0, 13.0)  # measured too high
 
         with pytest.raises(AFRValidationError):
-            calculate_ve_correction(13.0, 25.0)  # target too high
+            calculate_ve_correction(13.0, AFR_MAX + 10.0)  # target too high
 
         with pytest.raises(AFRValidationError):
-            calculate_ve_correction(20.1, 13.0)  # just above maximum
+            calculate_ve_correction(AFR_MAX + 0.1, 13.0)  # just above maximum
 
     @staticmethod
     def test_afr_zero_raises():

--- a/tools/autotune/__init__.py
+++ b/tools/autotune/__init__.py
@@ -1,0 +1,4 @@
+"""TuneLab autotune CLI package."""
+
+from __future__ import annotations
+

--- a/tools/autotune/__init__.py
+++ b/tools/autotune/__init__.py
@@ -1,4 +1,3 @@
 """TuneLab autotune CLI package."""
 
 from __future__ import annotations
-

--- a/tools/autotune/tunelab_entrypoint.py
+++ b/tools/autotune/tunelab_entrypoint.py
@@ -501,7 +501,8 @@ def _build_dual_grids_for_safety(
 
 
 def _safe_run_slug(run_id: str) -> str:
-    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", run_id.strip())
+    # Keep slugs filesystem-safe and traversal-resistant.
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "_", run_id.strip())
     return slug.strip("_") or "run"
 
 
@@ -547,9 +548,9 @@ def _build_safety_block(
         "rear": _neutral_grid(rows, cols, 100.0),
     }
     block_reasons = check_block_conditions(
-        base_ve=base_ve,  # type: ignore[arg-type]
-        corrections=corrections,  # type: ignore[arg-type]
-        hit_counts=hit_counts,  # type: ignore[arg-type]
+        base_ve=base_ve,
+        corrections=corrections,
+        hit_counts=hit_counts,
         rpm_axis=rpm_axis,
         map_axis=map_axis,
     )
@@ -564,8 +565,8 @@ def _build_safety_block(
             {
                 "type": "extreme_correction",
                 "message": (
-                    "Requested correction exceeds ±%.0f%% before clamp "
-                    "(overall_max_pct=%.2f%%)." % (block_threshold, overall_max_pct)
+                    f"Requested correction exceeds ±{block_threshold:.0f}% before clamp "
+                    f"(overall_max_pct={overall_max_pct:.2f}%)."
                 ),
             }
         )

--- a/tools/autotune/tunelab_entrypoint.py
+++ b/tools/autotune/tunelab_entrypoint.py
@@ -183,7 +183,24 @@ def _normalize_argv(argv: Sequence[str] | None) -> list[str]:
 
 
 def _normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
-    rename_map = {k: v for k, v in COLUMN_ALIASES.items() if k in df.columns}
+    """Rename alias columns to canonical names, but never produce duplicates.
+
+    If a canonical target column (e.g. ``AFR Meas F``) already exists, we
+    leave the alias column alone rather than renaming on top of it. Renaming
+    into an existing name yields duplicate column labels and turns
+    ``df[col]`` from a Series into a DataFrame, which silently breaks
+    downstream ``pd.to_numeric`` calls.
+    """
+    occupied: set[str] = set(df.columns)
+    rename_map: dict[str, str] = {}
+    for column in df.columns:
+        target = COLUMN_ALIASES.get(column)
+        if target is None:
+            continue
+        if target in occupied:
+            continue
+        rename_map[column] = target
+        occupied.add(target)
     if not rename_map:
         return df
     return df.rename(columns=rename_map)

--- a/tools/autotune/tunelab_entrypoint.py
+++ b/tools/autotune/tunelab_entrypoint.py
@@ -14,7 +14,11 @@ import numpy as np
 import pandas as pd  # type: ignore[import-untyped]
 
 from api.services.autotune.safety_gates import SAFETY, check_block_conditions
-from api.services.autotune_workflow import AutoTuneWorkflow, DataSource, VECorrectionResult
+from api.services.autotune_workflow import (
+    AutoTuneWorkflow,
+    DataSource,
+    VECorrectionResult,
+)
 from api.services.jetdrive.jetdrive_mapping import lambda_to_afr
 from api.services.jetdrive.wideband_rescale import (
     canonicalize_wideband_sample,
@@ -289,11 +293,15 @@ def _rescale_lambda_values_in_afr_columns(df: pd.DataFrame) -> pd.DataFrame:
             continue
 
         df[column] = [
-            None
-            if pd.isna(v)
-            else (lambda_to_afr(float(v))
-                  if LAMBDA_MIN_PLAUSIBLE <= float(v) <= LAMBDA_MAX_PLAUSIBLE
-                  else None)
+            (
+                None
+                if pd.isna(v)
+                else (
+                    lambda_to_afr(float(v))
+                    if LAMBDA_MIN_PLAUSIBLE <= float(v) <= LAMBDA_MAX_PLAUSIBLE
+                    else None
+                )
+            )
             for v in numeric
         ]
 
@@ -439,7 +447,9 @@ def _neutral_grid(rows: int, cols: int, value: float) -> list[list[float]]:
 def _build_dual_grids_for_safety(
     results: dict[str, dict[str, Any]],
     active_sides: Sequence[str],
-) -> tuple[dict[str, list[list[float]]], dict[str, list[list[float]]], list[float], list[float]]:
+) -> tuple[
+    dict[str, list[list[float]]], dict[str, list[list[float]]], list[float], list[float]
+]:
     reference_side = active_sides[0]
     rpm_axis = [float(v) for v in results[reference_side]["rpm_axis"]]
     map_axis = [float(v) for v in results[reference_side]["map_axis"]]
@@ -538,8 +548,7 @@ def _build_safety_block(
                 "type": "extreme_correction",
                 "message": (
                     "Requested correction exceeds ±%.0f%% before clamp "
-                    "(overall_max_pct=%.2f%%)."
-                    % (block_threshold, overall_max_pct)
+                    "(overall_max_pct=%.2f%%)." % (block_threshold, overall_max_pct)
                 ),
             }
         )
@@ -552,11 +561,15 @@ def _build_safety_block(
     }
 
 
-def _load_multiplier_csv(multiplier_csv: Path) -> tuple[list[str], list[int], list[list[float]]]:
+def _load_multiplier_csv(
+    multiplier_csv: Path,
+) -> tuple[list[str], list[int], list[list[float]]]:
     try:
         frame = pd.read_csv(multiplier_csv)
     except Exception as exc:
-        raise RuntimeError(f"unable_to_read_multiplier_csv: {multiplier_csv} ({exc})") from exc
+        raise RuntimeError(
+            f"unable_to_read_multiplier_csv: {multiplier_csv} ({exc})"
+        ) from exc
 
     if frame.empty or len(frame.columns) < 2:
         raise RuntimeError(f"invalid_multiplier_csv: {multiplier_csv}")
@@ -587,7 +600,10 @@ def _write_percent_factor_csv(
         writer = csv.writer(handle)
         writer.writerow(["RPM", *map_axis])
         for rpm, multiplier_row in zip(rpm_axis, multiplier_grid):
-            percent_row = [f"{(float(multiplier) - 1.0) * 100.0:.6f}" for multiplier in multiplier_row]
+            percent_row = [
+                f"{(float(multiplier) - 1.0) * 100.0:.6f}"
+                for multiplier in multiplier_row
+            ]
             writer.writerow([rpm, *percent_row])
 
 
@@ -665,7 +681,9 @@ def run_preview_cli(
             output_dir=output_dir,
         )
 
-    overall_max_pct = max(float(results[side]["requested_max_pct"]) for side in active_sides)
+    overall_max_pct = max(
+        float(results[side]["requested_max_pct"]) for side in active_sides
+    )
     safety = _build_safety_block(
         results=results,
         active_sides=active_sides,

--- a/tools/autotune/tunelab_entrypoint.py
+++ b/tools/autotune/tunelab_entrypoint.py
@@ -633,9 +633,7 @@ def _resolve_run_dir(run_id: str) -> Path:
     as a defense-in-depth guard.
     """
     runs_root = (REPO_ROOT / "runs").resolve()
-    raw_parts = [
-        part for part in run_id.replace("\\", "/").split("/") if part.strip()
-    ]
+    raw_parts = [part for part in run_id.replace("\\", "/").split("/") if part.strip()]
     safe_parts = [_safe_run_slug(part) for part in raw_parts]
     safe_parts = [part for part in safe_parts if part and part not in (".", "..")]
     if not safe_parts:

--- a/tools/autotune/tunelab_entrypoint.py
+++ b/tools/autotune/tunelab_entrypoint.py
@@ -608,13 +608,34 @@ def _write_percent_factor_csv(
 
 
 def _resolve_run_dir(run_id: str) -> Path:
-    run_dir = REPO_ROOT / "runs"
-    for part in run_id.replace("\\", "/").split("/"):
-        cleaned = part.strip()
-        if cleaned:
-            run_dir = run_dir / cleaned
-    run_dir.mkdir(parents=True, exist_ok=True)
-    return run_dir
+    """Resolve runs/<sanitized_run_id> within REPO_ROOT.
+
+    Sanitizes each path segment via ``_safe_run_slug`` so values containing
+    ``..``, drive letters, or stray separators cannot escape the runs root.
+    The final resolved path is also re-checked against ``runs_root.resolve()``
+    as a defense-in-depth guard.
+    """
+    runs_root = (REPO_ROOT / "runs").resolve()
+    raw_parts = [
+        part for part in run_id.replace("\\", "/").split("/") if part.strip()
+    ]
+    safe_parts = [_safe_run_slug(part) for part in raw_parts]
+    safe_parts = [part for part in safe_parts if part and part not in (".", "..")]
+    if not safe_parts:
+        raise RuntimeError(f"invalid_run_id_after_sanitization: {run_id!r}")
+
+    run_dir = runs_root
+    for part in safe_parts:
+        run_dir = run_dir / part
+    resolved = run_dir.resolve()
+    try:
+        resolved.relative_to(runs_root)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError(
+            f"run_id_escapes_runs_root: {run_id!r} -> {resolved}"
+        ) from exc
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
 
 
 def _load_summary(summary_path: Path) -> dict[str, Any]:

--- a/tools/autotune/tunelab_entrypoint.py
+++ b/tools/autotune/tunelab_entrypoint.py
@@ -1,0 +1,846 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd  # type: ignore[import-untyped]
+
+from api.services.autotune.safety_gates import SAFETY, check_block_conditions
+from api.services.autotune_workflow import AutoTuneWorkflow, DataSource, VECorrectionResult
+from api.services.jetdrive.jetdrive_mapping import lambda_to_afr
+from api.services.jetdrive.wideband_rescale import (
+    canonicalize_wideband_sample,
+    match_wideband_channel,
+)
+from api.services.powercore_integration import TuneFile, TuneTable, generate_pvv_xml
+from api.services.session_logger import SessionLogger
+from dynoai.core.ve_operations import VEApply
+
+LAMBDA_MIN_PLAUSIBLE = 0.5
+LAMBDA_MAX_PLAUSIBLE = 1.5
+APPLY_MAX_ADJUST_PCT = 15.0
+
+DEFAULT_AFR_TARGET_SOURCE = "static_map_curve_v1"
+AFR_TARGET_SOURCE_CHOICES = (DEFAULT_AFR_TARGET_SOURCE, "from_tune.AFR_Target")
+BASE_REQUIRED_COLUMNS = ("Engine RPM", "MAP kPa")
+CYLINDER_SPECS: dict[str, str] = {
+    "front": "AFR Meas F",
+    "rear": "AFR Meas R",
+}
+SINGLE_CYLINDER_CHOICES = ("front", "rear")
+MODE_DUAL = "dual_cylinder"
+MODE_SINGLE_FRONT = "single_cylinder_front"
+MODE_SINGLE_REAR = "single_cylinder_rear"
+MODE_CHOICES = (MODE_DUAL, MODE_SINGLE_FRONT, MODE_SINGLE_REAR)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Accept common aliases that can appear in Power Core exports.
+COLUMN_ALIASES = {
+    "RPM": "Engine RPM",
+    "MAP": "MAP kPa",
+    "MAP_kPa": "MAP kPa",
+    "AFR Front": "AFR Meas F",
+    "AFR Rear": "AFR Meas R",
+    "WBO2 F": "AFR Meas F",
+    "WBO2 R": "AFR Meas R",
+    "Air/Fuel Ratio 1": "AFR Meas F",
+    "Air/Fuel Ratio 2": "AFR Meas R",
+}
+
+
+def _add_preview_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--log-csv",
+        type=Path,
+        required=True,
+        help="Input log CSV with Engine RPM, MAP kPa, AFR Meas F, AFR Meas R.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory where correction CSVs and correction_summary.json are written.",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional run identifier to include in correction_summary.json metadata.",
+    )
+    parser.add_argument(
+        "--engine-family",
+        default=None,
+        help="Optional engine family metadata value for correction_summary.json.",
+    )
+    parser.add_argument(
+        "--displacement-ci",
+        type=float,
+        default=None,
+        help="Optional displacement metadata value for correction_summary.json.",
+    )
+    parser.add_argument(
+        "--afr-target-source",
+        choices=AFR_TARGET_SOURCE_CHOICES,
+        default=DEFAULT_AFR_TARGET_SOURCE,
+        help=(
+            '"static_map_curve_v1" (default MAP-indexed target curve) or '
+            '"from_tune.AFR_Target" (reserved for F1.1).'
+        ),
+    )
+    parser.add_argument(
+        "--single-cylinder",
+        choices=SINGLE_CYLINDER_CHOICES,
+        default=None,
+        help=(
+            "Run autotune for a single cylinder only (front or rear). "
+            "The other cylinder is reported as null in the summary and no "
+            "CSV is emitted for it. F1 default is dual-cylinder."
+        ),
+    )
+    parser.add_argument(
+        "--emit-pvv-patch",
+        action="store_true",
+        help="Emit dynoai_ve_correction_<run>.pvv alongside correction CSVs.",
+    )
+
+
+def _add_apply_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--run-id",
+        required=True,
+        help="Run identifier used for session logging under runs/<run_id>/.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory containing correction_summary.json and correction CSVs.",
+    )
+    parser.add_argument(
+        "--base-front",
+        type=Path,
+        required=True,
+        help="Front base VE CSV read from the currently loaded tune table.",
+    )
+    parser.add_argument(
+        "--base-rear",
+        type=Path,
+        required=True,
+        help="Rear base VE CSV read from the currently loaded tune table.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=MODE_CHOICES,
+        default=MODE_DUAL,
+        help="Expected mode from correction_summary.json (apply supports dual only).",
+    )
+    parser.add_argument(
+        "--max-adjust-pct",
+        type=float,
+        default=APPLY_MAX_ADJUST_PCT,
+        help="VEApply clamp percent for the apply pass.",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="TuneLab F1 CLI (preview + apply).",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    preview_parser = subparsers.add_parser(
+        "preview",
+        help="Generate per-cylinder correction previews.",
+    )
+    _add_preview_args(preview_parser)
+
+    apply_parser = subparsers.add_parser(
+        "apply",
+        help="Apply preview corrections using VEApply + SessionLogger.",
+    )
+    _add_apply_args(apply_parser)
+    return parser
+
+
+def _normalize_argv(argv: Sequence[str] | None) -> list[str]:
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if args and args[0] in {"preview", "apply", "-h", "--help"}:
+        return args
+    if not args:
+        return ["preview"]
+    return ["preview", *args]
+
+
+def _normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    rename_map = {k: v for k, v in COLUMN_ALIASES.items() if k in df.columns}
+    if not rename_map:
+        return df
+    return df.rename(columns=rename_map)
+
+
+def _convert_voltage_columns_to_afr(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert any LC-1/LC-2 voltage columns to canonical AFR columns.
+
+    Delegates all math to ``api.services.jetdrive.wideband_rescale`` so the
+    repo rule "single point of conversion" stays intact.
+    """
+    for column in list(df.columns):
+        canonical = match_wideband_channel(column)
+        if canonical is None:
+            continue
+
+        target_column = {
+            "AFR Front": "AFR Meas F",
+            "AFR Rear": "AFR Meas R",
+            "AFR": "AFR Meas",
+        }.get(canonical)
+        if target_column is None or target_column in df.columns:
+            continue
+
+        numeric_volts = pd.to_numeric(df[column], errors="coerce")
+        converted: list[float | None] = []
+        for raw in numeric_volts:
+            if pd.isna(raw):
+                converted.append(None)
+                continue
+            sample = canonicalize_wideband_sample(column, float(raw))
+            converted.append(sample.afr if sample is not None else None)
+        df[target_column] = converted
+
+    return df
+
+
+def _match_lambda_column(column_name: str) -> str | None:
+    """Return the canonical AFR column name if this column looks like Lambda.
+
+    Conservative: requires "lambda" in the column name. Distinguishes front
+    vs rear by suffix tokens ("1", "front", "f") / ("2", "rear", "r").
+    """
+    lowered = column_name.lower()
+    if "lambda" not in lowered:
+        return None
+    if "1" in lowered or "front" in lowered or lowered.endswith(" f"):
+        return "AFR Meas F"
+    if "2" in lowered or "rear" in lowered or lowered.endswith(" r"):
+        return "AFR Meas R"
+    return "AFR Meas"
+
+
+def _convert_lambda_columns_to_afr(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert any Lambda columns to canonical AFR columns.
+
+    Uses ``api.services.jetdrive.jetdrive_mapping.lambda_to_afr`` (stoich
+    gasoline: AFR = lambda * 14.7) so conversion math stays centralized.
+    Only rescales values that fall in a plausible Lambda range; stray
+    non-Lambda noise gets dropped to NaN to avoid silent AFR inflation.
+    """
+    for column in list(df.columns):
+        canonical_afr = _match_lambda_column(column)
+        if canonical_afr is None:
+            continue
+        if canonical_afr in df.columns:
+            continue
+
+        numeric = pd.to_numeric(df[column], errors="coerce")
+        converted: list[float | None] = []
+        for raw in numeric:
+            if pd.isna(raw):
+                converted.append(None)
+                continue
+            value = float(raw)
+            if not (LAMBDA_MIN_PLAUSIBLE <= value <= LAMBDA_MAX_PLAUSIBLE):
+                converted.append(None)
+                continue
+            converted.append(lambda_to_afr(value))
+        df[canonical_afr] = converted
+
+    return df
+
+
+def _rescale_lambda_values_in_afr_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Rescue: if a column named "AFR ..." actually holds Lambda values.
+
+    Some Power Core / DynoWare rigs mis-configure channel scaling so that
+    an ``AFR`` channel carries Lambda (0.5-1.5) values instead. The main
+    symptom is AutoTuneWorkflow rejecting values like 0.58 or 0.90 as
+    "outside valid AFR range". When the median of an AFR column sits in
+    the Lambda window, multiply by the stoich constant (delegated to
+    ``jetdrive_mapping.lambda_to_afr``) so downstream math gets AFR.
+    """
+    for column in list(df.columns):
+        lower = column.lower()
+        if "afr" not in lower:
+            continue
+
+        numeric = pd.to_numeric(df[column], errors="coerce")
+        valid = numeric.dropna()
+        if valid.empty:
+            continue
+
+        median_value = float(valid.median())
+        if not (LAMBDA_MIN_PLAUSIBLE <= median_value <= LAMBDA_MAX_PLAUSIBLE):
+            continue
+
+        df[column] = [
+            None
+            if pd.isna(v)
+            else (lambda_to_afr(float(v))
+                  if LAMBDA_MIN_PLAUSIBLE <= float(v) <= LAMBDA_MAX_PLAUSIBLE
+                  else None)
+            for v in numeric
+        ]
+
+    return df
+
+
+def _load_log_dataframe(log_csv: Path) -> pd.DataFrame:
+    try:
+        df = pd.read_csv(log_csv)
+    except Exception as exc:
+        raise RuntimeError(f"unable_to_read_csv: {exc}") from exc
+    df = _normalize_columns(df)
+    df = _convert_voltage_columns_to_afr(df)
+    df = _convert_lambda_columns_to_afr(df)
+    df = _rescale_lambda_values_in_afr_columns(df)
+    return df
+
+
+def _validate_required_columns(df: pd.DataFrame, active_sides: Sequence[str]) -> None:
+    required = list(BASE_REQUIRED_COLUMNS)
+    for side in active_sides:
+        required.append(CYLINDER_SPECS[side])
+    missing = [col for col in required if col not in df.columns]
+    if missing:
+        raise RuntimeError(f"missing_column: {missing[0]}")
+
+
+def _default_run_id(log_csv: Path) -> str:
+    date_part = datetime.now(timezone.utc).strftime("%Y%m%d")
+    return f"auto/{date_part}/{log_csv.stem}"
+
+
+def _format_axis_value(value: float) -> str:
+    as_float = float(value)
+    if as_float.is_integer():
+        return str(int(as_float))
+    return f"{as_float:.3f}".rstrip("0").rstrip(".")
+
+
+def _write_correction_csv(corrections: VECorrectionResult, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        map_axis = [_format_axis_value(v) for v in corrections.map_axis]
+        handle.write("RPM\\MAP," + ",".join(map_axis) + "\n")
+        for row_idx, rpm in enumerate(corrections.rpm_axis):
+            values = [
+                f"{float(corrections.correction_table[row_idx, col_idx]):.4f}"
+                for col_idx in range(len(corrections.map_axis))
+            ]
+            handle.write(_format_axis_value(rpm) + "," + ",".join(values) + "\n")
+
+
+def _build_cylinder_dataframe(df: pd.DataFrame, *, afr_column: str) -> pd.DataFrame:
+    non_afr_columns = [c for c in df.columns if "AFR" not in c]
+    out_df = df[non_afr_columns].copy()
+    out_df["AFR Meas"] = pd.to_numeric(df[afr_column], errors="coerce")
+    out_df["Engine RPM"] = pd.to_numeric(out_df["Engine RPM"], errors="coerce")
+    out_df["MAP kPa"] = pd.to_numeric(out_df["MAP kPa"], errors="coerce")
+    out_df = out_df.dropna(subset=["Engine RPM", "MAP kPa", "AFR Meas"])
+    if out_df.empty:
+        raise RuntimeError(f"no_valid_samples: {afr_column}")
+    return out_df
+
+
+def _run_for_cylinder(
+    source_df: pd.DataFrame,
+    *,
+    run_id: str,
+    cylinder_name: str,
+    afr_column: str,
+    output_dir: Path,
+) -> dict[str, Any]:
+    workflow = AutoTuneWorkflow()
+    session = workflow.create_session(
+        run_id=f"{run_id}_{cylinder_name}",
+        data_source=DataSource.CSV,
+    )
+
+    cylinder_df = _build_cylinder_dataframe(source_df, afr_column=afr_column)
+    if not workflow.import_dataframe(session, cylinder_df, source=DataSource.CSV):
+        detail = session.errors[-1] if session.errors else "unknown_import_failure"
+        raise RuntimeError(f"import_failed_{cylinder_name}: {detail}")
+
+    if workflow.analyze_afr(session) is None:
+        detail = session.errors[-1] if session.errors else "unknown_analyze_failure"
+        raise RuntimeError(f"analyze_failed_{cylinder_name}: {detail}")
+
+    corrections = workflow.calculate_corrections(session)
+    if corrections is None:
+        detail = session.errors[-1] if session.errors else "unknown_correction_failure"
+        raise RuntimeError(f"correction_failed_{cylinder_name}: {detail}")
+
+    csv_name = f"VE_{cylinder_name.capitalize()}_Correction_2D.csv"
+    csv_path = output_dir / csv_name
+    _write_correction_csv(corrections, csv_path)
+
+    session_summary = workflow.get_session_summary(session)
+    analysis = session_summary.get("analysis", {})
+    corr_summary = session_summary.get("ve_corrections", {})
+    hit_counts = (
+        session.afr_analysis.hit_count_by_zone.values.tolist()
+        if session.afr_analysis is not None
+        else []
+    )
+    requested_max_pct = max(
+        abs(float(analysis.get("max_lean_pct", 0.0))),
+        abs(float(analysis.get("max_rich_pct", 0.0))),
+    )
+
+    return {
+        "csv": csv_name,
+        "csv_path": str(csv_path.resolve()),
+        "zones_adjusted": int(corr_summary.get("zones_adjusted", 0)),
+        "max_pct": float(corr_summary.get("max_correction_pct", 0.0)),
+        "min_pct": float(corr_summary.get("min_correction_pct", 0.0)),
+        "clipped_zones": int(corr_summary.get("clipped_zones", 0)),
+        "mean_afr_error": float(analysis.get("mean_afr_error", 0.0)),
+        "mean_ve_delta_pct": float(analysis.get("mean_ve_delta_pct", 0.0)),
+        "requested_max_pct": float(requested_max_pct),
+        "rpm_axis": list(corrections.rpm_axis),
+        "map_axis": list(corrections.map_axis),
+        "correction_grid": corrections.correction_table.tolist(),
+        "hit_count_grid": hit_counts,
+    }
+
+
+def _cylinder_section(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "csv": result["csv"],
+        "zones_adjusted": result["zones_adjusted"],
+        "max_pct": result["max_pct"],
+        "min_pct": result["min_pct"],
+        "clipped_zones": result["clipped_zones"],
+        "mean_afr_error": result["mean_afr_error"],
+        "mean_ve_delta_pct": result["mean_ve_delta_pct"],
+    }
+
+
+def _neutral_grid(rows: int, cols: int, value: float) -> list[list[float]]:
+    return [[float(value) for _ in range(cols)] for _ in range(rows)]
+
+
+def _build_dual_grids_for_safety(
+    results: dict[str, dict[str, Any]],
+    active_sides: Sequence[str],
+) -> tuple[dict[str, list[list[float]]], dict[str, list[list[float]]], list[float], list[float]]:
+    reference_side = active_sides[0]
+    rpm_axis = [float(v) for v in results[reference_side]["rpm_axis"]]
+    map_axis = [float(v) for v in results[reference_side]["map_axis"]]
+    rows = len(rpm_axis)
+    cols = len(map_axis)
+
+    corrections = {
+        "front": (
+            results["front"]["correction_grid"]
+            if "front" in results
+            else _neutral_grid(rows, cols, 1.0)
+        ),
+        "rear": (
+            results["rear"]["correction_grid"]
+            if "rear" in results
+            else _neutral_grid(rows, cols, 1.0)
+        ),
+    }
+    hit_counts = {
+        "front": (
+            results["front"]["hit_count_grid"]
+            if "front" in results and results["front"]["hit_count_grid"]
+            else _neutral_grid(rows, cols, 0.0)
+        ),
+        "rear": (
+            results["rear"]["hit_count_grid"]
+            if "rear" in results and results["rear"]["hit_count_grid"]
+            else _neutral_grid(rows, cols, 0.0)
+        ),
+    }
+    return corrections, hit_counts, rpm_axis, map_axis
+
+
+def _safe_run_slug(run_id: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", run_id.strip())
+    return slug.strip("_") or "run"
+
+
+def _emit_pvv_patch(
+    *,
+    run_id: str,
+    output_dir: Path,
+    results: dict[str, dict[str, Any]],
+    active_sides: Sequence[str],
+) -> Path:
+    tune = TuneFile()
+    for side in active_sides:
+        side_result = results[side]
+        tune.tables[f"VE Correction {side.capitalize()}"] = TuneTable(
+            name=f"VE Correction {side.capitalize()}",
+            units="%",
+            row_axis=[float(rpm) for rpm in side_result["rpm_axis"]],
+            row_units="RPM",
+            col_axis=[float(map_kpa) for map_kpa in side_result["map_axis"]],
+            col_units="MAP (KPa)",
+            values=np.array(side_result["correction_grid"], dtype=float) * 100.0,
+        )
+    slug = _safe_run_slug(run_id)
+    pvv_path = output_dir / f"dynoai_ve_correction_{slug}.pvv"
+    pvv_path.write_text(generate_pvv_xml(tune), encoding="utf-8")
+    return pvv_path
+
+
+def _build_safety_block(
+    *,
+    results: dict[str, dict[str, Any]],
+    active_sides: Sequence[str],
+    overall_max_pct: float,
+) -> dict[str, Any]:
+    corrections, hit_counts, rpm_axis, map_axis = _build_dual_grids_for_safety(
+        results,
+        active_sides,
+    )
+    rows = len(rpm_axis)
+    cols = len(map_axis)
+    base_ve = {
+        "front": _neutral_grid(rows, cols, 100.0),
+        "rear": _neutral_grid(rows, cols, 100.0),
+    }
+    block_reasons = check_block_conditions(
+        base_ve=base_ve,  # type: ignore[arg-type]
+        corrections=corrections,  # type: ignore[arg-type]
+        hit_counts=hit_counts,  # type: ignore[arg-type]
+        rpm_axis=rpm_axis,
+        map_axis=map_axis,
+    )
+    block_threshold = float(SAFETY["block_raw_delta_pct"])
+    warn_threshold = float(SAFETY["warn_raw_delta_pct"])
+    over_block_threshold = bool(overall_max_pct > block_threshold)
+    has_extreme_reason = any(
+        reason.get("type") == "extreme_correction" for reason in block_reasons
+    )
+    if over_block_threshold and not has_extreme_reason:
+        block_reasons.append(
+            {
+                "type": "extreme_correction",
+                "message": (
+                    "Requested correction exceeds ±%.0f%% before clamp "
+                    "(overall_max_pct=%.2f%%)."
+                    % (block_threshold, overall_max_pct)
+                ),
+            }
+        )
+    return {
+        "block_threshold_pct": block_threshold,
+        "warn_threshold_pct": warn_threshold,
+        "over_block_threshold": over_block_threshold,
+        "apply_blocked": bool(block_reasons),
+        "apply_blocked_reasons": block_reasons,
+    }
+
+
+def _load_multiplier_csv(multiplier_csv: Path) -> tuple[list[str], list[int], list[list[float]]]:
+    try:
+        frame = pd.read_csv(multiplier_csv)
+    except Exception as exc:
+        raise RuntimeError(f"unable_to_read_multiplier_csv: {multiplier_csv} ({exc})") from exc
+
+    if frame.empty or len(frame.columns) < 2:
+        raise RuntimeError(f"invalid_multiplier_csv: {multiplier_csv}")
+
+    first_col = frame.columns[0]
+    frame = frame.rename(columns={first_col: "RPM"})
+    rpm_values = pd.to_numeric(frame["RPM"], errors="coerce")
+    if rpm_values.isna().any():
+        raise RuntimeError(f"invalid_rpm_column: {multiplier_csv}")
+    rpm_axis = [int(float(v)) for v in rpm_values.tolist()]
+
+    map_columns = [str(col) for col in frame.columns[1:]]
+    numeric_values = frame.iloc[:, 1:].apply(pd.to_numeric, errors="coerce")
+    if numeric_values.isna().any().any():
+        raise RuntimeError(f"invalid_multiplier_values: {multiplier_csv}")
+
+    return map_columns, rpm_axis, numeric_values.to_numpy(dtype=float).tolist()
+
+
+def _write_percent_factor_csv(
+    *,
+    multiplier_csv: Path,
+    factor_csv: Path,
+) -> None:
+    map_axis, rpm_axis, multiplier_grid = _load_multiplier_csv(multiplier_csv)
+    factor_csv.parent.mkdir(parents=True, exist_ok=True)
+    with factor_csv.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["RPM", *map_axis])
+        for rpm, multiplier_row in zip(rpm_axis, multiplier_grid):
+            percent_row = [f"{(float(multiplier) - 1.0) * 100.0:.6f}" for multiplier in multiplier_row]
+            writer.writerow([rpm, *percent_row])
+
+
+def _resolve_run_dir(run_id: str) -> Path:
+    run_dir = REPO_ROOT / "runs"
+    for part in run_id.replace("\\", "/").split("/"):
+        cleaned = part.strip()
+        if cleaned:
+            run_dir = run_dir / cleaned
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def _load_summary(summary_path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(summary_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"unable_to_read_summary: {exc}") from exc
+
+
+def _get_required_section(summary: dict[str, Any], side: str) -> dict[str, Any]:
+    section = summary.get(side)
+    if not isinstance(section, dict):
+        raise RuntimeError(f"missing_summary_section: {side}")
+    if "csv" not in section:
+        raise RuntimeError(f"missing_summary_csv_field: {side}")
+    return section
+
+
+def _flatten_reason_messages(reasons: list[dict[str, Any]]) -> str:
+    messages = [str(reason.get("message", "")).strip() for reason in reasons]
+    non_empty = [message for message in messages if message]
+    return "; ".join(non_empty) if non_empty else "Safety gates blocked apply."
+
+
+def run_preview_cli(
+    *,
+    log_csv: Path,
+    output_dir: Path,
+    run_id: str | None,
+    engine_family: str | None,
+    displacement_ci: float | None,
+    afr_target_source: str,
+    single_cylinder: str | None = None,
+    emit_pvv_patch: bool = False,
+) -> Path:
+    if afr_target_source == "from_tune.AFR_Target":
+        raise RuntimeError("unsupported_afr_target_source: from_tune.AFR_Target (F1.1)")
+
+    if single_cylinder is not None and single_cylinder not in SINGLE_CYLINDER_CHOICES:
+        raise RuntimeError(f"invalid_single_cylinder: {single_cylinder}")
+
+    if single_cylinder == "front":
+        active_sides = ["front"]
+        mode = MODE_SINGLE_FRONT
+    elif single_cylinder == "rear":
+        active_sides = ["rear"]
+        mode = MODE_SINGLE_REAR
+    else:
+        active_sides = ["front", "rear"]
+        mode = MODE_DUAL
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_df = _load_log_dataframe(log_csv)
+    _validate_required_columns(source_df, active_sides)
+
+    resolved_run_id = run_id or _default_run_id(log_csv)
+    results: dict[str, dict[str, Any]] = {}
+    for side in active_sides:
+        results[side] = _run_for_cylinder(
+            source_df,
+            run_id=resolved_run_id,
+            cylinder_name=side,
+            afr_column=CYLINDER_SPECS[side],
+            output_dir=output_dir,
+        )
+
+    overall_max_pct = max(float(results[side]["requested_max_pct"]) for side in active_sides)
+    safety = _build_safety_block(
+        results=results,
+        active_sides=active_sides,
+        overall_max_pct=overall_max_pct,
+    )
+    warn_threshold = float(safety["warn_threshold_pct"])
+
+    reference_side = active_sides[0]
+    summary: dict[str, Any] = {
+        "schema_version": 1,
+        "log_csv": str(log_csv.resolve()),
+        "run_id": resolved_run_id,
+        "mode": mode,
+        "afr_target_source": afr_target_source,
+        "grid": {
+            "rpm_axis": results[reference_side]["rpm_axis"],
+            "map_axis": results[reference_side]["map_axis"],
+        },
+        "front": _cylinder_section(results["front"]) if "front" in results else None,
+        "rear": _cylinder_section(results["rear"]) if "rear" in results else None,
+        "overall_max_pct": overall_max_pct,
+        "warn_threshold_pct": warn_threshold,
+        "over_warn_threshold": overall_max_pct > warn_threshold,
+        "safety": safety,
+    }
+
+    if engine_family is not None:
+        summary["engine_family"] = engine_family
+    if displacement_ci is not None:
+        summary["displacement_ci"] = displacement_ci
+    if emit_pvv_patch:
+        pvv_path = _emit_pvv_patch(
+            run_id=resolved_run_id,
+            output_dir=output_dir,
+            results=results,
+            active_sides=active_sides,
+        )
+        summary["pvv_patch"] = pvv_path.name
+
+    summary_path = output_dir / "correction_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return summary_path.resolve()
+
+
+def run_apply_cli(
+    *,
+    run_id: str,
+    output_dir: Path,
+    base_front: Path,
+    base_rear: Path,
+    mode: str = MODE_DUAL,
+    max_adjust_pct: float = APPLY_MAX_ADJUST_PCT,
+) -> tuple[Path, Path, Path]:
+    summary_path = output_dir / "correction_summary.json"
+    if not summary_path.exists():
+        raise RuntimeError(f"missing_summary: {summary_path}")
+
+    summary = _load_summary(summary_path)
+    summary_mode = str(summary.get("mode", MODE_DUAL))
+    if mode != MODE_DUAL or summary_mode != MODE_DUAL:
+        raise RuntimeError(
+            f"apply_requires_dual_cylinder_mode: requested={mode} summary={summary_mode}"
+        )
+
+    safety = summary.get("safety", {})
+    if bool(safety.get("apply_blocked")):
+        reasons_raw = safety.get("apply_blocked_reasons", [])
+        reasons = [reason for reason in reasons_raw if isinstance(reason, dict)]
+        raise RuntimeError(f"apply_blocked: {_flatten_reason_messages(reasons)}")
+
+    front_section = _get_required_section(summary, "front")
+    rear_section = _get_required_section(summary, "rear")
+
+    front_multiplier_csv = output_dir / str(front_section["csv"])
+    rear_multiplier_csv = output_dir / str(rear_section["csv"])
+    if not front_multiplier_csv.exists():
+        raise RuntimeError(f"missing_front_multiplier_csv: {front_multiplier_csv}")
+    if not rear_multiplier_csv.exists():
+        raise RuntimeError(f"missing_rear_multiplier_csv: {rear_multiplier_csv}")
+    if not base_front.exists():
+        raise RuntimeError(f"missing_base_front: {base_front}")
+    if not base_rear.exists():
+        raise RuntimeError(f"missing_base_rear: {base_rear}")
+
+    front_factor_pct_csv = output_dir / "VE_Front_Correction_Pct.csv"
+    rear_factor_pct_csv = output_dir / "VE_Rear_Correction_Pct.csv"
+    _write_percent_factor_csv(
+        multiplier_csv=front_multiplier_csv,
+        factor_csv=front_factor_pct_csv,
+    )
+    _write_percent_factor_csv(
+        multiplier_csv=rear_multiplier_csv,
+        factor_csv=rear_factor_pct_csv,
+    )
+
+    front_applied_csv = output_dir / "VE_Front_Applied.csv"
+    rear_applied_csv = output_dir / "VE_Rear_Applied.csv"
+    applier = VEApply(max_adjust_pct=max_adjust_pct)
+    front_meta = applier.apply(
+        base_ve_path=base_front,
+        factor_path=front_factor_pct_csv,
+        output_path=front_applied_csv,
+        dry_run=False,
+    )
+    rear_meta = applier.apply(
+        base_ve_path=base_rear,
+        factor_path=rear_factor_pct_csv,
+        output_path=rear_applied_csv,
+        dry_run=False,
+    )
+
+    resolved_run_id = run_id or str(summary.get("run_id", "")).strip()
+    if not resolved_run_id:
+        raise RuntimeError("missing_run_id")
+
+    run_dir = _resolve_run_dir(resolved_run_id)
+    logger = SessionLogger(run_dir)
+    logger.record_apply(
+        ve_before_path=base_front,
+        ve_after_path=front_applied_csv,
+        apply_metadata={**front_meta, "cylinder": "front"},
+        description=f"Applied front VE corrections (max ±{max_adjust_pct:.1f}%)",
+    )
+    logger.record_apply(
+        ve_before_path=base_rear,
+        ve_after_path=rear_applied_csv,
+        apply_metadata={**rear_meta, "cylinder": "rear"},
+        description=f"Applied rear VE corrections (max ±{max_adjust_pct:.1f}%)",
+    )
+    session_log_path = run_dir / "session_log.json"
+    return (
+        front_applied_csv.resolve(),
+        rear_applied_csv.resolve(),
+        session_log_path.resolve(),
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    normalized_argv = _normalize_argv(argv)
+    args = parser.parse_args(normalized_argv)
+
+    try:
+        if args.command == "preview":
+            summary_path = run_preview_cli(
+                log_csv=args.log_csv,
+                output_dir=args.output_dir,
+                run_id=args.run_id,
+                engine_family=args.engine_family,
+                displacement_ci=args.displacement_ci,
+                afr_target_source=args.afr_target_source,
+                single_cylinder=args.single_cylinder,
+                emit_pvv_patch=args.emit_pvv_patch,
+            )
+            print(f"[F1][OK] summary={summary_path}")
+            return 0
+        if args.command == "apply":
+            apply_front, apply_rear, session_log = run_apply_cli(
+                run_id=args.run_id,
+                output_dir=args.output_dir,
+                base_front=args.base_front,
+                base_rear=args.base_rear,
+                mode=args.mode,
+                max_adjust_pct=args.max_adjust_pct,
+            )
+            print(
+                f"[F1][OK] apply_front={apply_front} "
+                f"apply_rear={apply_rear} session_log={session_log}"
+            )
+            return 0
+        raise RuntimeError(f"unsupported_command: {args.command}")
+    except Exception as exc:
+        print(f"[F1][ERR] {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **F1 autotune preview** (`feat(f1)`): adds the full per-cylinder VE correction pipeline driven from inside TuneLab/Power Core. `tunelab_entrypoint.py` runs `AutoTuneWorkflow` twice (Front AFR + Rear AFR), produces `VE_Front_Correction_2D.csv`, `VE_Rear_Correction_2D.csv`, and `correction_summary.json`. `dynoai_autotune.py` is an IronPython 2.7 TuneLab script that exports the loaded log, shells to the CLI, and shows a WinForms preview dialog (Export Only / Cancel — no PutTable writes in this release). `safety_gates.py` provides shared block/warn thresholds.
- **AFR bounds fix** (`fix(ve-math)`): widens `AFR_MIN`/`AFR_MAX` from `[9.0, 20.0]` to `[7.0, 23.0]` to match the full Innovate LC-1/LC-2 sensor calibration range. Tests updated to use the constants.
- **Dep cleanup** (`chore(deps)`): normalises npm peer-dep flags in `package-lock.json`.

## Test plan
- [x] `pytest tests/unit/test_tunelab_autotune_cli.py` — 5 CLI cases (missing column, happy path, over-threshold, front vs rear diverge, stdout format)
- [x] `pytest tests/unit/test_ve_math.py` — AFR bounds tests use constants, pass at new range
- [ ] Manual Power Core validation: load a Harley log with both `WBO2 F` and `WBO2 R`, run `dynoai_autotune.py`, confirm preview dialog, click Export Only, verify both correction CSVs + summary JSON in `runs/<run_id>/corrections/`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds new TuneLab (IronPython) autotune preview/apply bridge plus new safety gating logic and kernel-sentinel clamps/halts that directly affect tuning outputs and live alerting. Also expands workspace session schema/APIs, so regressions could impact session persistence and operational readiness flows.
> 
> **Overview**
> Enables **TuneLab/Power Core autotune preview + optional dual-cylinder apply** by adding a large IronPython `dynoai_autotune.py` bridge that exports loaded logs to CSV, shells out to a Python CLI, displays a WinForms summary, and (when unblocked) writes applied VE tables back via `context.PutTable` with audit/export artifacts.
> 
> Adds **server-side safety infrastructure**: new `api/services/autotune/safety_gates.py` for shared apply-block rules (shape/base/partial-cylinder/extreme correction), expands `wideband_rescale.match_wideband_channel` to recognize more voltage-channel name variants, and introduces `dynoai/core/kernel_sentinel.py` with clamp-tightening and halt-on-breach checks; `AutoTuneWorkflow` and `jetdrive_realtime_analysis` now consult this sentinel (including new injector duty alerts).
> 
> Extends the **workspace/session API** with v3 session payload CRUD, blocker resolution, phased pull tracking, dispatch readiness evaluation, and P0 plausibility checks; `TuningSession` persistence is updated for forward-compatible loading/validation via new Pydantic `session_v3` models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d4258cb8ca3f27e07b651bcdf2f5e0df959f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->