### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Architecture
+
+DynoAI3 is a monorepo with two required services for development:
+
+| Service | Stack | Port | Start command |
+|---------|-------|------|---------------|
+| Backend API | Python / Flask | 5001 | `PYTHONPATH=. python3 -m api.app` |
+| Frontend | React / Vite / TypeScript | 5173 | `cd frontend && npm run dev` |
+
+SQLite is the default database (auto-created at `./dynoai.db`, zero config). Redis and PostgreSQL are optional (only for production).
+
+### Running services
+
+- **Backend**: `PYTHONPATH=. DYNOAI_DEBUG=true python3 -m api.app` from workspace root. The `PYTHONPATH=.` is required so Python can resolve `api.*` and `dynoai.*` imports.
+- **Frontend**: `npm run dev` from `frontend/`. Vite proxies `/api` requests to `http://localhost:5001` automatically (configured in `vite.config.ts`).
+- Use `python3` not `python` — the VM may not have a `python` symlink.
+
+### Dependency installation
+
+There are two Python requirements files with a **Flask version conflict** (`requirements.txt` pins `flask==3.1.0`, `api/requirements.txt` pins `flask==3.1.3`). Install them sequentially — `requirements.txt` first, then `api/requirements.txt` — so the API's newer Flask version wins. Also install `bcrypt` (needed by `api/models/user.py` but not listed in either requirements file).
+
+```bash
+pip install -r requirements.txt
+pip install -r api/requirements.txt
+pip install -e ".[dev,test]"
+pip install bcrypt
+```
+
+Frontend uses npm with `package-lock.json`:
+
+```bash
+cd frontend && npm ci --legacy-peer-deps
+```
+
+### Lint / Test / Build
+
+| Check | Command | Notes |
+|-------|---------|-------|
+| Python lint | `ruff check .` | Pre-existing warnings exist; `--fix` can auto-fix some |
+| Python format | `black --check .` | Pre-existing formatting issues exist |
+| Python tests | `PYTHONPATH=. pytest tests/ -v` | ~1260 tests; ~27 pre-existing failures in API auth tests and physics simulator |
+| Frontend lint | `cd frontend && npx eslint .` | Pre-existing TS errors exist |
+| Frontend tests | `cd frontend && npx vitest run` | ~41 tests; 1 pre-existing failure in pvvParser |
+| Frontend build | `cd frontend && npm run build` | TypeScript + Vite production build |
+
+### Gotchas
+
+- The `api.app` module auto-starts the Flask server when imported as `api.app` (not just `__main__`). Set `PYTEST_CURRENT_TEST=1` env var if you need to import `api.app` without it starting the server.
+- `DYNOAI_STANDALONE` env var disables some features (rate limiting, root route). Do not set it for normal dev.
+- JetDrive hardware features work in **stub/simulator mode** by default (`JETSTREAM_STUB_MODE=true` in `.env`), so no physical dyno hardware is needed.
+- The workspace rule in `.cursor/rules/no-physics-in-frontend.mdc` forbids physics/math computations in frontend code. Read it before editing any frontend files that deal with numeric values.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `AGENTS.md` with development environment setup instructions for Cursor Cloud agents. This enables future cloud agents to quickly understand the project structure, start services, run tests, and avoid common gotchas.

## Type of Change

- [x] Documentation update

## Changes Made

- Created `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering:
  - Architecture overview (Flask backend on port 5001, Vite frontend on port 5173)
  - Service start commands with required environment variables
  - Dependency installation steps including Flask version conflict workaround
  - Lint/test/build command reference with notes on pre-existing issues
  - Development gotchas (auto-start behavior, stub mode, no-physics-in-frontend rule)

## Testing

- [x] Manually tested the changes
- All documented commands were verified during environment setup:
  - Backend API starts successfully and responds to health checks
  - Frontend dev server starts and serves the React app
  - pytest runs (1257 passed, 27 pre-existing failures)
  - vitest runs (40 passed, 1 pre-existing failure)
  - ruff and eslint lint checks execute correctly

## Demo

[dynoai_dev_env_demo.mp4](https://cursor.com/agents/bc-dabb42e2-a3fc-4ba3-8e64-42d313b946a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdynoai_dev_env_demo.mp4)

[DynoAI Frontend Main Page](https://cursor.com/agents/bc-dabb42e2-a3fc-4ba3-8e64-42d313b946a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_main_page.webp)
[JetDrive Page with VE Heatmap](https://cursor.com/agents/bc-dabb42e2-a3fc-4ba3-8e64-42d313b946a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjetdrive_page.webp)
[API Health Endpoint Response](https://cursor.com/agents/bc-dabb42e2-a3fc-4ba3-8e64-42d313b946a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_health_check.webp)

## Math-Critical Changes

- [x] This PR does NOT modify math-critical files (core/ or experiments/protos/)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dabb42e2-a3fc-4ba3-8e64-42d313b946a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dabb42e2-a3fc-4ba3-8e64-42d313b946a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

